### PR TITLE
feat : 방 생성 API 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,22 +32,22 @@ jobs:
         with:
           arguments: clean test
 
-      # 테스트 결과 PR 코멘트에 등록
-      - name: Register the test results as PR comments
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: |
-            **/api/build/test-results/test/TEST-*.xml
-            **/core/build/test-results/test/TEST-*.xml
-
-
-      # 테스트 실패시 코드 라인에 대한 체크 추가
-      - name: If test fail, add check comment on failed code line
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: |
-            **/api/build/test-results/test/TEST-*.xml
-            **/core/build/test-results/test/TEST-*.xml
+#      # 테스트 결과 PR 코멘트에 등록
+#      - name: Register the test results as PR comments
+#        uses: EnricoMi/publish-unit-test-result-action@v2
+#        if: always()
+#        with:
+#          files: |
+#            **/api/build/test-results/test/TEST-*.xml
+#            **/core/build/test-results/test/TEST-*.xml
+#
+#
+#      # 테스트 실패시 코드 라인에 대한 체크 추가
+#      - name: If test fail, add check comment on failed code line
+#        uses: mikepenz/action-junit-report@v3
+#        if: always()
+#        with:
+#          report_paths: |
+#            **/api/build/test-results/test/TEST-*.xml
+#            **/core/build/test-results/test/TEST-*.xml
 

--- a/api/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomApiMapper.java
@@ -1,0 +1,28 @@
+package com.civilwar.boardsignal.room.dto.mapper;
+
+import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomApiMapper {
+
+    public static CreateRoomRequest toCreateRoomRequest(ApiCreateRoomRequest request){
+        return new CreateRoomRequest(
+            request.time(),
+            request.description(),
+            request.minPartipants(),
+            request.maxPartipants(),
+            request.day(),
+            request.time(),
+            request.startTime(),
+            request.minAge(),
+            request.maxAge(),
+            request.subwayLine(),
+            request.subwayStation(),
+            request.place(),
+            request.categories()
+        );
+    }
+}

--- a/api/src/main/java/com/civilwar/boardsignal/room/dto/request/ApiCreateRoomRequest.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/dto/request/ApiCreateRoomRequest.java
@@ -1,0 +1,21 @@
+package com.civilwar.boardsignal.room.dto.request;
+
+import java.util.List;
+
+public record ApiCreateRoomRequest(
+    String roomTitle,
+    String description,
+    int minPartipants,
+    int maxPartipants,
+    String day,
+    String time,
+    String startTime,
+    int minAge,
+    int maxAge,
+    String subwayLine,
+    String subwayStation,
+    String place,
+    List<String> categories
+) {
+
+}

--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -1,0 +1,42 @@
+package com.civilwar.boardsignal.room.presentation;
+
+import com.civilwar.boardsignal.room.application.RoomService;
+import com.civilwar.boardsignal.room.dto.mapper.RoomApiMapper;
+import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Room API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rooms")
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @Operation(summary = "방 생성 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping
+    public ResponseEntity<CreateRoomResponse> createRoom(
+        @AuthenticationPrincipal User user,
+        @Valid @RequestBody ApiCreateRoomRequest request
+    ) {
+        CreateRoomRequest createRoomRequest = RoomApiMapper.toCreateRoomRequest(request);
+
+        CreateRoomResponse createRoomResponse = roomService.createRoom(user, createRoomRequest);
+
+        return ResponseEntity.ok(createRoomResponse);
+    }
+}

--- a/api/src/test/java/com/civilwar/boardsignal/common/support/ApiTestSupport.java
+++ b/api/src/test/java/com/civilwar/boardsignal/common/support/ApiTestSupport.java
@@ -1,10 +1,16 @@
 package com.civilwar.boardsignal.common.support;
 
+import com.civilwar.boardsignal.auth.domain.TokenProvider;
+import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.support.DatabaseCleaner;
 import com.civilwar.boardsignal.support.DatabaseCleanerExtension;
 import com.civilwar.boardsignal.support.TestContainerSupport;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,10 +25,31 @@ import org.springframework.test.web.servlet.MockMvc;
 public abstract class ApiTestSupport extends TestContainerSupport {
 
     protected final ObjectMapper objectMapper = new ObjectMapper();
+
     @Autowired
     protected MockMvc mockMvc;
 
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    protected User loginUser;
+    protected String accessToken;
+
     protected String toJson(Object object) throws JsonProcessingException {
         return objectMapper.writeValueAsString(object);
+    }
+
+    // API 테스트할 때마다 User 를 저장하고 토큰정보를 가져오지 않기 위해서 하나의 유저와 토큰정보 구성
+    @PostConstruct
+    public void setUpUser() {
+        if (loginUser != null) {
+            return;
+        }
+        User user = userRepository.save(UserFixture.getUserFixture("prpr", "image"));
+        Token token = tokenProvider.createToken(user.getId(), user.getRole());
+        this.loginUser = user;
+        this.accessToken = "Bearer " + token.accessToken();
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -1,0 +1,61 @@
+package com.civilwar.boardsignal.room.presentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.civilwar.boardsignal.common.support.ApiTestSupport;
+import com.civilwar.boardsignal.room.RoomFixture;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
+import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@DisplayName("[RoomController 테스트]")
+class RoomControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Test
+    @DisplayName("[사용자는 방을 생성할 수 있다.]")
+    void createRoom() throws Exception {
+        ApiCreateRoomRequest request = new ApiCreateRoomRequest(
+            "무슨무슨 모임입니다!",
+            "재밌게 하려고 모집중",
+            1,
+            6,
+            "주말",
+            "오전",
+            "토요일 오후 3:30",
+            21,
+            25,
+            "7호선",
+            "이수역",
+            "레드버튼 사당점",
+            List.of("가족게임", "컬렉터블게임")
+        );
+
+
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/rooms")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(AUTHORIZATION, accessToken)
+                .content(toJson(request)))
+            .andExpect(status().isOk());
+
+        Room room = roomRepository.findById(1L).orElseThrow();
+
+        resultActions.andExpect(jsonPath("$.roomId").value(room.getId()));
+
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -1,0 +1,34 @@
+package com.civilwar.boardsignal.room.application;
+
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
+import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
+import com.civilwar.boardsignal.room.dto.mapper.RoomMapper;
+import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+    private final ParticipantRepository participantRepository;
+
+    @Transactional
+    public CreateRoomResponse createRoom(User user, CreateRoomRequest request) {
+        Room room = RoomMapper.toRoom(request);
+        Room savedRoom = roomRepository.save(room);
+
+        Participant participant = Participant.of(user.getId(),
+            savedRoom.getId()); // 나중에 방 폭파 때 해당 방의 Participant 전부 삭제
+        participantRepository.save(participant);
+
+        return RoomMapper.toCreateRoomResponse(savedRoom);
+    }
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/DaySlot.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/DaySlot.java
@@ -1,5 +1,10 @@
 package com.civilwar.boardsignal.room.domain.constants;
 
+import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+
+import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.common.exception.NotFoundException;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +16,15 @@ public enum DaySlot {
     WEEKEND("주말");
 
     private final String description;
+
+    public static DaySlot of(String input) {
+        return Arrays.stream(values())
+            .filter(category -> category.isEqual(input))
+            .findAny()
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME));
+    }
+
+    private boolean isEqual(String input) {
+        return input.equalsIgnoreCase(this.description);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/TimeSlot.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/TimeSlot.java
@@ -1,5 +1,9 @@
 package com.civilwar.boardsignal.room.domain.constants;
 
+import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+
+import com.civilwar.boardsignal.common.exception.NotFoundException;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +15,15 @@ public enum TimeSlot {
     PM("오후");
 
     private final String description;
+
+    public static TimeSlot of(String input) {
+        return Arrays.stream(values())
+            .filter(category -> category.isEqual(input))
+            .findAny()
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME));
+    }
+
+    private boolean isEqual(String input) {
+        return input.equalsIgnoreCase(this.description);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Participant.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Participant.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,8 +16,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "PARTICIPANT_TABLE")
 public class Participant {
-
-    private static final String PARTICIPANT = "participant";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,4 +27,24 @@ public class Participant {
 
     @Column(name = "PARTICIPANT_ROOM_ID")
     private Long roomId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Participant(
+        Long userId,
+        Long roomId
+    ) {
+        this.userId = userId;
+        this.roomId = roomId;
+    }
+
+    public static Participant of(
+        Long userId,
+        Long roomId
+    )
+    {
+        return Participant.builder()
+            .userId(userId)
+            .roomId(roomId)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -4,7 +4,10 @@ import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 
+import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.room.domain.constants.DaySlot;
 import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
+import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,16 +21,17 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @NoArgsConstructor
 @Getter
 @Table(name = "ROOM_TABLE")
 public class Room {
-
-    private static final String ROOM = "room";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,20 +41,41 @@ public class Room {
     @Column(name = "ROOM_TITLE")
     private String title;
 
+    @Column(name = "ROOM_DESCRIPTION")
+    private String description;
+
     @Column(name = "ROOM_MIN_PARTICIPANTS")
     private int minParticipants;
 
     @Column(name = "ROOM_MAX_PARTICIPANTS")
     private int maxParticipants;
 
-    @Column(name = "ROOM_DESCRIPTION")
-    private String description;
-
     @Column(name = "ROOM_STATUS")
     private RoomStatus status;
 
     @Column(name = "ROOM_PLACE_NAME")
     private String placeName;
+
+    @Column(name = "ROOM_SUBWAY_LINE")
+    private String subwayLine;
+
+    @Column(name = "ROOM_SUBWAY_STATION")
+    private String subwayStation;
+
+    @Column(name = "ROOM_DAY_SLOT")
+    private DaySlot daySlot;
+
+    @Column(name = "ROOM_TIME_SLOT")
+    private TimeSlot timeSlot;
+
+    @Column(name = "ROOM_START_TIME")
+    private String startTime;
+
+    @Column(name = "ROOM_MIN_AGE")
+    private int minAge;
+
+    @Column(name = "ROOM_MAX_AGE")
+    private int maxAge;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ROOM_MEETING_INFO_ID", foreignKey = @ForeignKey(NO_CONSTRAINT))
@@ -59,9 +84,70 @@ public class Room {
     @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<RoomCategory> roomCategories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private List<Schedule> schedules = new ArrayList<>();
+    @Builder(access = AccessLevel.PRIVATE)
+    private Room(
+        @NonNull String title,
+        @NonNull String description,
+        int minParticipants,
+        int maxParticipants,
+        @NonNull String placeName,
+        @NonNull String subwayLine,
+        @NonNull String subwayStation,
+        @NonNull DaySlot daySlot,
+        @NonNull TimeSlot timeSlot,
+        @NonNull String startTime,
+        int minAge,
+        int maxAge,
+        @NonNull List<Category> roomCategories
+    ) {
+        this.title = title;
+        this.description = description;
+        this.minParticipants = minParticipants;
+        this.maxParticipants = maxParticipants;
+        this.status = RoomStatus.NON_FIX;
+        this.placeName = placeName;
+        this.subwayLine = subwayLine;
+        this.subwayStation = subwayStation;
+        this.daySlot = daySlot;
+        this.timeSlot = timeSlot;
+        this.startTime = startTime;
+        this.minAge = minAge;
+        this.maxAge = maxAge;
+        roomCategories.forEach(category -> {
+            RoomCategory roomCategory = RoomCategory.of(this, category);
+            this.roomCategories.add(roomCategory);
+        });
+    }
 
-    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private List<Subway> subways = new ArrayList<>();
+    public static Room of(
+        String title,
+        String description,
+        int minParticipants,
+        int maxParticipants,
+        String placeName,
+        String subwayLine,
+        String subwayStation,
+        DaySlot daySlot,
+        TimeSlot timeSlot,
+        String startTime,
+        int minAge,
+        int maxAge,
+        List<Category> roomCategories
+    ) {
+        return Room.builder()
+            .title(title)
+            .description(description)
+            .minParticipants(minParticipants)
+            .maxParticipants(maxParticipants)
+            .placeName(placeName)
+            .subwayLine(subwayLine)
+            .subwayStation(subwayStation)
+            .daySlot(daySlot)
+            .timeSlot(timeSlot)
+            .startTime(startTime)
+            .minAge(minAge)
+            .maxAge(maxAge)
+            .roomCategories(roomCategories)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/RoomCategory.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/RoomCategory.java
@@ -13,6 +13,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,4 +35,23 @@ public class RoomCategory {
 
     @Column(name = "ROOM_CATEGORY_CATEGORY")
     private Category category;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private RoomCategory(
+        Room room,
+        Category category
+    ) {
+        this.room = room;
+        this.category = category;
+    }
+
+    public static RoomCategory of(
+        Room room,
+        Category category
+    ){
+        return RoomCategory.builder()
+            .room(room)
+            .category(category)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
@@ -1,0 +1,12 @@
+package com.civilwar.boardsignal.room.domain.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import java.util.Collection;
+
+public interface ParticipantRepository {
+
+    Participant save(Participant participant);
+
+    void saveAll(Collection<Participant> participants);
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
@@ -1,0 +1,14 @@
+package com.civilwar.boardsignal.room.domain.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import java.util.Collection;
+import java.util.Optional;
+
+public interface RoomRepository {
+
+    Room save(Room room);
+
+    void saveAll(Collection<Room> rooms);
+
+    Optional<Room> findById(Long id);
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -1,0 +1,43 @@
+package com.civilwar.boardsignal.room.dto.mapper;
+
+import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.room.domain.constants.DaySlot;
+import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomMapper {
+
+    public static Room toRoom(CreateRoomRequest request) {
+        DaySlot daySlot = DaySlot.of(request.day());
+        TimeSlot timeSlot = TimeSlot.of(request.time());
+        List<Category> categories = request.categories().stream()
+            .map(Category::of)
+            .toList();
+
+        return Room.of(
+            request.roomTitle(),
+            request.description(),
+            request.minPartipants(),
+            request.maxPartipants(),
+            request.place(),
+            request.subwayLine(),
+            request.subwayStation(),
+            daySlot,
+            timeSlot,
+            request.startTime(),
+            request.minAge(),
+            request.maxAge(),
+            categories
+        );
+    }
+
+    public static CreateRoomResponse toCreateRoomResponse(Room room) {
+        return new CreateRoomResponse(room.getId());
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/request/CreateRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/request/CreateRoomResponse.java
@@ -1,0 +1,5 @@
+package com.civilwar.boardsignal.room.dto.request;
+
+public record CreateRoomResponse(Long roomId) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/CreateRoomRequest.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/CreateRoomRequest.java
@@ -1,0 +1,21 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+import java.util.List;
+
+public record CreateRoomRequest(
+    String roomTitle,
+    String description,
+    int minPartipants,
+    int maxPartipants,
+    String day,
+    String time,
+    String startTime,
+    int minAge,
+    int maxAge,
+    String subwayLine,
+    String subwayStation,
+    String place,
+    List<String> categories
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
@@ -1,0 +1,25 @@
+package com.civilwar.boardsignal.room.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
+import com.civilwar.boardsignal.room.infrastructure.repository.ParticipantJpaRepository;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ParticipantRepositoryAdaptor implements ParticipantRepository {
+
+    private final ParticipantJpaRepository participantJpaRepository;
+
+    @Override
+    public Participant save(Participant participant) {
+        return participantJpaRepository.save(participant);
+    }
+
+    @Override
+    public void saveAll(Collection<Participant> participants) {
+        participantJpaRepository.saveAll(participants);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -1,0 +1,31 @@
+package com.civilwar.boardsignal.room.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
+import com.civilwar.boardsignal.room.infrastructure.repository.RoomJpaRepository;
+import java.util.Collection;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomRepositoryAdaptor implements RoomRepository {
+
+    private final RoomJpaRepository roomJpaRepository;
+
+    @Override
+    public Room save(Room room) {
+        return roomJpaRepository.save(room);
+    }
+
+    @Override
+    public void saveAll(Collection<Room> rooms) {
+        roomJpaRepository.saveAll(rooms);
+    }
+
+    @Override
+    public Optional<Room> findById(Long id) {
+        return roomJpaRepository.findById(id);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantJpaRepository.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.room.infrastructure.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantJpaRepository extends JpaRepository<Participant, Long> {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.room.infrastructure.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomJpaRepository extends JpaRepository<Room, Long> {
+
+}

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -1,0 +1,55 @@
+package com.civilwar.boardsignal.room.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
+import com.civilwar.boardsignal.room.RoomFixture;
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
+import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
+import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("[RoomService 테스트]")
+@ExtendWith(MockitoExtension.class)
+class RoomServiceTest {
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @InjectMocks
+    private RoomService roomService;
+
+    @Test
+    @DisplayName("[방을 생성할 수 있다.]")
+    void createRoom() {
+        User user = UserFixture.getUserFixture("providerID", "imageUrl");
+        Room room = RoomFixture.getRoom();
+        Participant participant = RoomFixture.getParticipant();
+
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(room, "id", 1L);
+        CreateRoomRequest request = RoomFixture.getCreateRoomRequest();
+
+        given(roomRepository.save(any(Room.class))).willReturn(room);
+        given(participantRepository.save(any(Participant.class))).willReturn(participant);
+
+        CreateRoomResponse response = roomService.createRoom(user, request);
+
+        assertThat(response.roomId()).isEqualTo(room.getId());
+    }
+}

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
@@ -1,0 +1,45 @@
+package com.civilwar.boardsignal.room;
+
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.dto.mapper.RoomMapper;
+import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomFixture {
+
+    public static Room getRoom() {
+        return RoomMapper.toRoom(getCreateRoomRequest());
+    }
+
+    public static CreateRoomRequest getCreateRoomRequest() {
+        return new CreateRoomRequest(
+            "무슨무슨 모임입니다!",
+            "재밌게 하려고 모집중",
+            3,
+            6,
+            "주말",
+            "오전",
+            "이수역",
+            21,
+            25,
+            "7호선",
+            "이수역",
+            "레드버튼 사당점",
+            List.of("가족게임", "컬렉터블게임")
+        );
+    }
+
+    public static CreateRoomResponse getCreateRoomResponse() {
+        return new CreateRoomResponse(1L);
+    }
+
+    public static Participant getParticipant() {
+        return Participant.of(1L, 1L);
+    }
+
+}


### PR DESCRIPTION
- closed #6 

### ⛏ 작업 상세 내용

- 방 생성 api 구현
- 방 엔티티 요구사항 맞춰서 재정의하고 erd 수정해놨습니다.
- 방 생성 로직에서 Participant(유저-방 테이블) 생성해서 저장하는 로직까지 있습니다.
    - 나중에 방 폭파 구현할 때 해당 방의 Participant도 다 없애야 합니다!
- Conflict 많을 것 같은데 그건 머지전에 수정하겠습니다~

### ✅ 중점적으로 리뷰 할 부분

- 방 생성 로직 및 테스트 코드
- 방 엔티티 재설계 한 부분

### 참고사항
