### PR TITLE
feat : 로그아웃 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
@@ -2,8 +2,12 @@ package com.civilwar.boardsignal.auth.presentation;
 
 import com.civilwar.boardsignal.auth.application.AuthService;
 import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
+import com.civilwar.boardsignal.auth.dto.response.UserLogoutResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -42,11 +46,27 @@ public class AuthApiController {
     }
 
     @Operation(summary = "AccessToken 재발급 API", description = "Cookie에 RefreshToken Id 필요")
+    @ApiResponse(useReturnTypeSchema = true)
     @GetMapping("/reissue")
     public ResponseEntity<IssueTokenResponse> issueAccessToken(
         @CookieValue(name = "RefreshTokenId") String refreshTokenId
     ) {
         return ResponseEntity.ok(authService.issueAccessToken(refreshTokenId));
+    }
+
+    @Operation(summary = "AccessToken 재발급 API", description = "Cookie에 RefreshToken Id 필요")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/logout")
+    public ResponseEntity<UserLogoutResponse> logout(
+        @CookieValue(name = "RefreshTokenId") String refreshTokenId,
+        HttpServletResponse response
+    ) {
+        //쿠키 제거
+        Cookie cookie = new Cookie("RefreshTokenId", null);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+        //로그아웃 성공 시 true 반환
+        return ResponseEntity.ok(authService.logout(refreshTokenId));
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/application/AuthService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/application/AuthService.java
@@ -5,6 +5,7 @@ import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.auth.dto.request.UserLoginRequest;
 import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLoginResponse;
+import com.civilwar.boardsignal.auth.dto.response.UserLogoutResponse;
 import com.civilwar.boardsignal.auth.mapper.AuthMapper;
 import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
@@ -60,6 +61,12 @@ public class AuthService {
         //refreshTokenId를 통해 AccessToken 재발급
         String accessToken = tokenProvider.issueAccessToken(refreshTokenId);
         return AuthMapper.toIssueTokenResponse(accessToken);
+    }
+
+    public UserLogoutResponse logout(String refreshTokenId) {
+
+        //refreshToken 삭제 후, boolean 응답
+        return AuthMapper.toUserLogoutResponse(tokenProvider.deleteRefreshToken(refreshTokenId));
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/domain/RefreshTokenRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/domain/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ public interface RefreshTokenRepository {
 
     Optional<String> findById(String id);
 
+    Boolean delete(String id);
+
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/domain/TokenProvider.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/domain/TokenProvider.java
@@ -13,4 +13,6 @@ public interface TokenProvider {
     TokenPayload getPayLoad(String token);
 
     void validateToken(String token);
+
+    Boolean deleteRefreshToken(String refreshTokenId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/dto/response/UserLogoutResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/dto/response/UserLogoutResponse.java
@@ -1,0 +1,7 @@
+package com.civilwar.boardsignal.auth.dto.response;
+
+public record UserLogoutResponse(
+    Boolean logoutResult
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/auth/infrastructure/JwtTokenProvider.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/infrastructure/JwtTokenProvider.java
@@ -116,4 +116,9 @@ public class JwtTokenProvider implements TokenProvider {
     public void validateToken(String token) {
         getClaims(token);
     }
+
+    @Override
+    public Boolean deleteRefreshToken(String refreshTokenId) {
+        return refreshTokenRepository.delete(refreshTokenId);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/infrastructure/RefreshTokenRedisRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/infrastructure/RefreshTokenRedisRepository.java
@@ -25,4 +25,9 @@ public class RefreshTokenRedisRepository implements RefreshTokenRepository {
             .get(id));
     }
 
+    @Override
+    public Boolean delete(String id) {
+        return redisTemplate.delete(id);
+    }
+
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthMapper.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.auth.mapper;
 import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLoginResponse;
+import com.civilwar.boardsignal.auth.dto.response.UserLogoutResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +16,10 @@ public class AuthMapper {
 
     public static IssueTokenResponse toIssueTokenResponse(String accessToken) {
         return new IssueTokenResponse(accessToken);
+    }
+
+    public static UserLogoutResponse toUserLogoutResponse(Boolean logoutResult) {
+        return new UserLogoutResponse(logoutResult);
     }
 
 }

--- a/core/src/test/java/com/civilwar/boardsignal/auth/infrastructure/RefreshTokenRedisRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/auth/infrastructure/RefreshTokenRedisRepositoryTest.java
@@ -54,4 +54,19 @@ class RefreshTokenRedisRepositoryTest extends TestContainerSupport {
         //then
         assertThat(optional).contains(refreshToken);
     }
+
+    @Test
+    @DisplayName("[RefreshToken을 삭제한다]")
+    void deleteTest() {
+        //given
+        refreshTokenRepository.save(uuid, refreshToken, refreshExpiryTime);
+
+        //when
+        Boolean trueResult = refreshTokenRepository.delete(uuid);
+        Boolean falseResult = refreshTokenRepository.delete("NotSaveId");
+
+        //then
+        assertThat(trueResult).isTrue();
+        assertThat(falseResult).isFalse();
+    }
 }


### PR DESCRIPTION
- closed #3 

### ⛏ 작업 상세 내용

- 회원이 로그아웃 요청을 보낸다면
1. Redis에서 RefreshToken값을 삭제합니다.
2. Cookie의 RefreshToken ID를 삭제합니다

### ✅ 중점적으로 리뷰 할 부분

- 네이밍
- 전체적인 로직 흐름

### 참고사항

- 이번 태스크는 양이 적어서 금방 리뷰하실 것 같습니다!
- 중간중간  단위테스트는 무의미한 것 같아서
1. API 통합테스트
2. Redis 저장소 테스트
만 진행하였습니다!