### PR TITLE
feat : 보드게임 찜하기 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -4,13 +4,19 @@ import com.civilwar.boardsignal.boardgame.application.BoardGameService;
 import com.civilwar.boardsignal.boardgame.dto.request.BoardGameSearchCondition;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
+import com.civilwar.boardsignal.boardgame.dto.response.WishBoardGameResponse;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,4 +38,16 @@ public class BoardGameController {
             condition, pageable);
         return ResponseEntity.ok(boardGames);
     }
+
+    @Operation(summary = "보드게임 찜하기 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/wish/{boardGameId}")
+    public ResponseEntity<WishBoardGameResponse> wishBoardGame(
+        @AuthenticationPrincipal User user,
+        @PathVariable("boardGameId") Long boardGameId
+    ) {
+        WishBoardGameResponse response = boardGameService.wishBoardGame(user, boardGameId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.boardgame.presentation;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -69,6 +70,24 @@ class BoardGameControllerTest extends ApiTestSupport {
                 jsonPath("$.boardGamesInfos[0].imageUrl").value(boardGame2.getMainImageUrl()))
             .andExpect(jsonPath("$.size").value(1))
             .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("[특정 보드게임을 찜 등록을 하거나 취소할 수 있다.]")
+    void wishBoardGame() throws Exception {
+        int prevWishCount = boardGame1.getWishCount();
+        //찜 등록
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/board-games/wish/{boardGameId}",
+                    boardGame1.getId())
+                .header(AUTHORIZATION, accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.wishCount").value(prevWishCount + 1));
+        //찜 취소
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/board-games/wish/{boardGameId}",
+                    boardGame1.getId())
+                .header(AUTHORIZATION, accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.wishCount").value(prevWishCount));
     }
 
 }

--- a/api/src/test/java/com/civilwar/boardsignal/common/config/CorsConfig.java
+++ b/api/src/test/java/com/civilwar/boardsignal/common/config/CorsConfig.java
@@ -1,0 +1,19 @@
+package com.civilwar.boardsignal.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry){
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:5173")
+            .allowedMethods("GET", "POST", "PUT", "DELETE")
+            .allowCredentials(true)
+            .maxAge(3600);
+    }
+}

--- a/api/src/test/java/com/civilwar/boardsignal/common/config/CorsConfig.java
+++ b/api/src/test/java/com/civilwar/boardsignal/common/config/CorsConfig.java
@@ -8,8 +8,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @EnableWebMvc
 public class CorsConfig implements WebMvcConfigurer {
+
     @Override
-    public void addCorsMappings(CorsRegistry registry){
+    public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedOrigins("http://localhost:5173")
             .allowedMethods("GET", "POST", "PUT", "DELETE")

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.user.presentation;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,7 +17,6 @@ import com.civilwar.boardsignal.user.dto.request.ApiUserModifyRequest;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
@@ -1,11 +1,17 @@
 package com.civilwar.boardsignal.boardgame.application;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
+import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import com.civilwar.boardsignal.boardgame.domain.repository.BoardGameQueryRepository;
+import com.civilwar.boardsignal.boardgame.domain.repository.WishRepository;
 import com.civilwar.boardsignal.boardgame.dto.BoardGameMapper;
 import com.civilwar.boardsignal.boardgame.dto.request.BoardGameSearchCondition;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
+import com.civilwar.boardsignal.boardgame.dto.response.WishBoardGameResponse;
+import com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode;
+import com.civilwar.boardsignal.common.exception.NotFoundException;
+import com.civilwar.boardsignal.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -16,13 +22,36 @@ import org.springframework.stereotype.Service;
 public class BoardGameService {
 
     private final BoardGameQueryRepository boardGameQueryRepository;
+    private final WishRepository wishRepository;
 
     public BoardGamePageResponse<GetAllBoardGamesResponse> getAllBoardGames(
         BoardGameSearchCondition condition, Pageable pageable) {
 
         Slice<BoardGame> boardGames = boardGameQueryRepository.findAll(condition, pageable);
-        Slice<GetAllBoardGamesResponse> findBoardGames = boardGames.map(BoardGameMapper::toGetAllBoardGamesResponse); // 응답 dto 형식으로 변환
-      
+        Slice<GetAllBoardGamesResponse> findBoardGames = boardGames.map(
+            BoardGameMapper::toGetAllBoardGamesResponse); // 응답 dto 형식으로 변환
+
         return BoardGameMapper.toBoardGamePageRepsonse(findBoardGames); // 커스텀 페이징 응답 dto에 담음
+    }
+
+    public WishBoardGameResponse wishBoardGame(User user, Long boardGameId) {
+        BoardGame boardGame = boardGameQueryRepository.findById(boardGameId)
+            .orElseThrow(
+                () -> new NotFoundException(BoardGameErrorCode.NOT_FOUND_BOARD_GAME)
+            );
+
+        wishRepository.findByUserIdAndBoardGameId(user.getId(), boardGameId)
+            .ifPresentOrElse(
+                wish -> { // 찜한 내역이 있던 게임이라면 찜 취소 로직
+                    boardGame.decreaseWishCount();
+                    wishRepository.deleteById(wish.getId());
+                },
+                () -> { // 찜한 내역이 없던 게임이라면 찜 등록 로직
+                    boardGame.increaseWishCount();
+                    Wish wish = Wish.of(user.getId(), boardGameId);
+                    wishRepository.save(wish);
+                }
+            );
+        return new WishBoardGameResponse(boardGame.getWishCount());
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/BoardGame.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/BoardGame.java
@@ -116,4 +116,12 @@ public class BoardGame {
             .categories(categories)
             .build();
     }
+
+    public void increaseWishCount() {
+        this.wishCount += 1;
+    }
+
+    public void decreaseWishCount() {
+        this.wishCount -= 1;
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Wish.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Wish.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -28,8 +29,8 @@ public class Wish {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Wish(
-        Long userId,
-        Long boardGameId
+        @NonNull Long userId,
+        @NonNull Long boardGameId
     ) {
         this.userId = userId;
         this.boardGameId = boardGameId;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Wish.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Wish.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +25,23 @@ public class Wish {
     private Long userId;
 
     private Long boardGameId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Wish(
+        Long userId,
+        Long boardGameId
+    ) {
+        this.userId = userId;
+        this.boardGameId = boardGameId;
+    }
+
+    public static Wish of(
+        Long userId,
+        Long boardGameId
+    ) {
+        return Wish.builder()
+            .userId(userId)
+            .boardGameId(boardGameId)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/WishRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/WishRepository.java
@@ -1,0 +1,16 @@
+package com.civilwar.boardsignal.boardgame.domain.repository;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
+import java.util.Collection;
+import java.util.Optional;
+
+public interface WishRepository {
+
+    Optional<Wish> findByUserIdAndBoardGameId(Long userId, Long boardGameId);
+
+    Wish save(Wish wish);
+
+    void saveAll(Collection<Wish> wishes);
+
+    void deleteById(Long wishId);
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/WishBoardGameResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/WishBoardGameResponse.java
@@ -1,0 +1,5 @@
+package com.civilwar.boardsignal.boardgame.dto.response;
+
+public record WishBoardGameResponse(int wishCount) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/WishRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/WishRepositoryAdaptor.java
@@ -1,0 +1,36 @@
+package com.civilwar.boardsignal.boardgame.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
+import com.civilwar.boardsignal.boardgame.domain.repository.WishRepository;
+import com.civilwar.boardsignal.boardgame.infrastructure.repository.WishJpaRepository;
+import java.util.Collection;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WishRepositoryAdaptor implements WishRepository {
+
+    private final WishJpaRepository wishJpaRepository;
+
+    @Override
+    public Optional<Wish> findByUserIdAndBoardGameId(Long userId, Long boardGameId) {
+        return wishJpaRepository.findByUserIdAndBoardGameId(userId, boardGameId);
+    }
+
+    @Override
+    public Wish save(Wish wish) {
+        return wishJpaRepository.save(wish);
+    }
+
+    @Override
+    public void saveAll(Collection<Wish> wishes) {
+        wishJpaRepository.saveAll(wishes);
+    }
+
+    @Override
+    public void deleteById(Long wishId) {
+        wishJpaRepository.deleteById(wishId);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/WishJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/WishJpaRepository.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.boardgame.infrastructure.repository;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WishJpaRepository extends JpaRepository<Wish, Long> {
+
+    Optional<Wish> findByUserIdAndBoardGameId(Long userId, Long boardGameId);
+}

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/fixture/BoardGameFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/fixture/BoardGameFixture.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.boardgame.domain.constant.Difficulty;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGameCategory;
+import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -43,5 +44,9 @@ public class BoardGameFixture {
 
     public static BoardGameCategory getBoardGameCategory(Category category) {
         return BoardGameCategory.of(category);
+    }
+
+    public static Wish getWish(Long userId, Long boardGameId) {
+        return Wish.of(userId, boardGameId);
     }
 }


### PR DESCRIPTION
- closed #22 

### ⛏ 작업 상세 내용

- 찜 등록 api 구현
- 찜 등록 시에 이미 찜한 게임이라면 찜을 취소하는 로직으로 구현했습니다. 반대로 찜하지 않았던 게임이라면 찜 등록 로직을 수행하게 했습니다.

### ✅ 중점적으로 리뷰 할 부분

- 찜 등록 로직
- 테스트 코드
- 컨벤션 놓친 거 없는 지

### 참고사항

- 찜 등록 시에 보드게임 조회, 찜 조회, 찜 insert(delete), 보드게임 업데이트(찜 수) 이렇게 쿼리가 네방 나갑니다ㅠㅠ
    - 이게 최선이라 생각해서 이렇게 짰는데 좋은 의견 있을 시 남겨주세용 
