### PR TITLE
feat : 유저는 프로필을 조회할 수 있다.

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
@@ -5,14 +5,18 @@ import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.dto.request.ApiUserModifyRequest;
 import com.civilwar.boardsignal.user.dto.request.UserModifyRequest;
 import com.civilwar.boardsignal.user.dto.response.UserModifyResponse;
+import com.civilwar.boardsignal.user.dto.response.UserProfileResponse;
 import com.civilwar.boardsignal.user.mapper.UserApiMapper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -33,7 +37,7 @@ public class UserApiController {
     public ResponseEntity<UserModifyResponse> modifyUser(
         @Valid @RequestPart(value = "data") ApiUserModifyRequest apiUserModifyRequest,
         @RequestPart(value = "image", required = false) MultipartFile image,
-        @AuthenticationPrincipal User user
+        @Parameter(hidden = true) @AuthenticationPrincipal User user
     ) {
         UserModifyRequest userModifyRequest = UserApiMapper.toUserModifyRequest(user.getId(),
             apiUserModifyRequest,
@@ -42,6 +46,28 @@ public class UserApiController {
         UserModifyResponse userModifyResponse = userService.modifyUser(userModifyRequest);
 
         return ResponseEntity.ok(userModifyResponse);
+    }
+
+    @Operation(summary = "본인 프로필 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/my")
+    public ResponseEntity<UserProfileResponse> getUserProfile(
+        @Parameter(hidden = true) @AuthenticationPrincipal User user
+    ) {
+        UserProfileResponse userProfileResponse = userService.getUserProfileInfo(user.getId());
+
+        return ResponseEntity.ok(userProfileResponse);
+    }
+
+    @Operation(summary = "타인 프로필 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserProfileResponse> getAnotherUserProfile(
+        @PathVariable("userId") Long id
+    ) {
+        UserProfileResponse userProfileResponse = userService.getUserProfileInfo(id);
+
+        return ResponseEntity.ok(userProfileResponse);
     }
 
 }

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -1,6 +1,8 @@
 package com.civilwar.boardsignal.user.presentation;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -8,6 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.civilwar.boardsignal.auth.domain.TokenProvider;
 import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.common.support.ApiTestSupport;
+import com.civilwar.boardsignal.review.ReviewFixture;
+import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
 import com.civilwar.boardsignal.user.UserFixture;
 import com.civilwar.boardsignal.user.domain.constants.OAuthProvider;
 import com.civilwar.boardsignal.user.domain.constants.Role;
@@ -17,11 +24,9 @@ import com.civilwar.boardsignal.user.dto.request.ApiUserModifyRequest;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -31,6 +36,8 @@ class UserApiControllerTest extends ApiTestSupport {
 
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
     @Autowired
     private TokenProvider tokenProvider;
 
@@ -73,7 +80,7 @@ class UserApiControllerTest extends ApiTestSupport {
                     .file(data)
                     .accept(MediaType.APPLICATION_JSON)
                     .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+                    .header(AUTHORIZATION, "Bearer " + token.accessToken())
             )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(userId));
@@ -85,5 +92,34 @@ class UserApiControllerTest extends ApiTestSupport {
         assertThat(findUser.getNickname()).isEqualTo(apiUserModifyRequest.nickName());
         assertThat(findUser.getLine()).isEqualTo(apiUserModifyRequest.line());
         assertThat(findUser.getStation()).isEqualTo(apiUserModifyRequest.station());
+    }
+
+    @Test
+    @DisplayName("유저의 프로필을 조회할 수 있다.")
+    void getUserProfileTest() throws Exception {
+        //given
+        List<ReviewEvaluation> evaluationFixture = ReviewFixture.getEvaluationFixture();
+        Review review = ReviewFixture.getReviewFixture(100L, loginUser.getId(), 1L,
+            evaluationFixture);
+        reviewRepository.save(review);
+
+        //then
+        mockMvc.perform(get("/api/v1/users/my")
+                .header(AUTHORIZATION, accessToken))
+            .andExpect(jsonPath("$.nickname").value(loginUser.getNickname()))
+            .andExpect(jsonPath("$.signal").value(loginUser.getSignal()))
+            .andExpect(jsonPath("$.gender").value(loginUser.getGender().getDescription()))
+            .andExpect(jsonPath("$.ageGroup").value(loginUser.getAgeGroup().getDescription()))
+            .andExpect(jsonPath("$.profileImageUrl").value(loginUser.getProfileImageUrl()))
+            .andExpect(jsonPath("$.mannerScore").value(loginUser.getMannerScore()))
+            .andExpect(jsonPath("$.reviews[0].content").value(
+                ReviewContent.TIME_COMMITMENT.getDescription()))
+            .andExpect(jsonPath("$.reviews[0].score").value(
+                1))
+            .andExpect(jsonPath("$.reviews[1].content").value(
+                ReviewContent.GOOD_MANNER.getDescription()))
+            .andExpect(jsonPath("$.reviews[1].score").value(
+                0));
+
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -121,6 +121,10 @@ class UserApiControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.reviews[1].content").value(
                 ReviewContent.GOOD_MANNER.getDescription()))
             .andExpect(jsonPath("$.reviews[1].score").value(
+                0))
+            .andExpect(jsonPath("$.reviews[2].content").value(
+                ReviewContent.FAST_RESPONSE.getDescription()))
+            .andExpect(jsonPath("$.reviews[2].score").value(
                 0));
 
     }

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/constant/ReviewContent.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/constant/ReviewContent.java
@@ -1,0 +1,15 @@
+package com.civilwar.boardsignal.review.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewContent {
+    TIME_COMMITMENT("시간 약속을 잘 지켜요"),
+    GOOD_MANNER("친절하고 매너가 좋아요"),
+    FAST_RESPONSE("응답이 빨라요");
+
+    private final String description;
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/Review.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/Review.java
@@ -12,8 +12,11 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -23,11 +26,47 @@ public class Review {
 
     @OneToMany(mappedBy = "review", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     List<ReviewEvaluation> reviewEvaluations = new ArrayList<>();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "REVIEW_ID")
     private Long id;
+
+    @Column(name = "REVIEW_REVIEWER_ID")
     private Long reviewerId;
+
+    @Column(name = "REVIEW_REVIEWEE_ID")
     private Long revieweeId;
+
+    @Column(name = "REVIEW_ROOM_ID")
     private Long roomId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Review(
+        @NonNull Long reviewerId,
+        @NonNull Long revieweeId,
+        @NonNull Long roomId,
+        @NonNull List<ReviewEvaluation> reviewEvaluations
+    ) {
+        this.reviewerId = reviewerId;
+        this.revieweeId = revieweeId;
+        this.roomId = roomId;
+        this.reviewEvaluations.addAll(reviewEvaluations);
+        reviewEvaluations
+            .forEach(evaluation -> evaluation.associateReview(this));
+    }
+
+    public static Review of(
+        Long reviewerId,
+        Long revieweeId,
+        Long roomId,
+        List<ReviewEvaluation> reviewEvaluations
+    ) {
+        return Review.builder()
+            .reviewerId(reviewerId)
+            .revieweeId(revieweeId)
+            .roomId(roomId)
+            .reviewEvaluations(reviewEvaluations)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/ReviewEvaluation.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/ReviewEvaluation.java
@@ -1,10 +1,12 @@
 package com.civilwar.boardsignal.review.domain.entity;
 
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
+import static jakarta.persistence.EnumType.*;
 
 import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -35,6 +37,7 @@ public class ReviewEvaluation {
     private Review review;
 
     @Column(name = "REVIEW_EVALUATION_CONTENT")
+    @Enumerated(STRING)
     private ReviewContent content;
 
     @Column(name = "REVIEW_IS_RECOMMENDED")

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/ReviewEvaluation.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/ReviewEvaluation.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.review.domain.entity;
 
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 
+import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,8 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -23,16 +27,39 @@ public class ReviewEvaluation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ROOM_ID")
+    @Column(name = "REVIEW_EVALUATION_ID")
     private Long id;
 
     @JoinColumn(name = "review_id", foreignKey = @ForeignKey(NO_CONSTRAINT))
     @ManyToOne(fetch = FetchType.LAZY)
     private Review review;
 
-    private String content;
+    @Column(name = "REVIEW_EVALUATION_CONTENT")
+    private ReviewContent content;
 
-    private int likeCount;
+    @Column(name = "REVIEW_IS_RECOMMENDED")
+    private int isRecommended;
 
-    private int dislikeCount;
+    @Builder(access = AccessLevel.PRIVATE)
+    public ReviewEvaluation(
+        @NonNull ReviewContent content,
+        int isRecommended
+    ) {
+        this.content = content;
+        this.isRecommended = isRecommended;
+    }
+
+    public static ReviewEvaluation of(
+        ReviewContent content,
+        int isRecommended
+    ) {
+        return ReviewEvaluation.builder()
+            .content(content)
+            .isRecommended(isRecommended)
+            .build();
+    }
+
+    public void associateReview(Review review) {
+        this.review = review;
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/repository/ReviewRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/repository/ReviewRepository.java
@@ -1,0 +1,16 @@
+package com.civilwar.boardsignal.review.domain.repository;
+
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewRepository {
+
+    Review save(Review review);
+
+    Optional<Review> findById(Long id);
+
+    List<Review> findAll();
+
+    List<Review> findReviewsByRevieweeId(Long userId);
+}

--- a/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/adaptor/ReviewRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/adaptor/ReviewRepositoryAdaptor.java
@@ -1,0 +1,36 @@
+package com.civilwar.boardsignal.review.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
+import com.civilwar.boardsignal.review.infrastructure.repository.ReviewJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryAdaptor implements ReviewRepository {
+
+    private final ReviewJpaRepository reviewJpaRepository;
+
+    @Override
+    public Review save(Review review) {
+        return reviewJpaRepository.save(review);
+    }
+
+    @Override
+    public Optional<Review> findById(Long id) {
+        return reviewJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Review> findAll() {
+        return reviewJpaRepository.findAll();
+    }
+
+    @Override
+    public List<Review> findReviewsByRevieweeId(Long userId) {
+        return reviewJpaRepository.findReviewsByRevieweeId(userId);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepository.java
@@ -1,0 +1,16 @@
+package com.civilwar.boardsignal.review.infrastructure.repository;
+
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+
+    @Query("select r from Review as r "
+        + "join fetch r.reviewEvaluations "
+        + "where r.revieweeId = :userId")
+    List<Review> findReviewsByRevieweeId(@Param("userId") Long userId);
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/user/application/UserService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/application/UserService.java
@@ -6,8 +6,12 @@ import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import com.civilwar.boardsignal.user.dto.request.UserModifyRequest;
 import com.civilwar.boardsignal.user.dto.response.UserModifyResponse;
+import com.civilwar.boardsignal.user.dto.response.UserProfileResponse;
+import com.civilwar.boardsignal.user.dto.response.UserReviewResponse;
 import com.civilwar.boardsignal.user.exception.UserErrorCode;
+import com.civilwar.boardsignal.user.facade.UserReviewFacade;
 import com.civilwar.boardsignal.user.mapper.UserMapper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ImageRepository imageRepository;
+    private final UserReviewFacade userReviewFacade;
 
     @Transactional
     public UserModifyResponse modifyUser(UserModifyRequest userModifyRequest) {
@@ -38,6 +43,18 @@ public class UserService {
         );
 
         return UserMapper.toUserModifyResponse(findUser);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfileInfo(Long id) {
+        //유저 정보 조회
+        User findUser = userRepository.findById(id)
+            .orElseThrow(() -> new NotFoundException(UserErrorCode.NOT_FOUND_USER));
+
+        //유저와 관련된 리뷰 정보 조회
+        List<UserReviewResponse> userReviews = userReviewFacade.getUserReview(id);
+
+        return UserMapper.toUserProfileResponse(findUser, userReviews);
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/UserCategory.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/UserCategory.java
@@ -1,6 +1,5 @@
 package com.civilwar.boardsignal.user.domain.entity;
 
-import static com.civilwar.boardsignal.common.exception.CommonValidationError.getNotNullMessage;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 import static jakarta.persistence.EnumType.STRING;
 
@@ -20,7 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -44,9 +43,11 @@ public class UserCategory {
     private Category category;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private UserCategory(User user, Category category) {
-        Assert.notNull(category, getNotNullMessage(USER_CATEGORY, "category"));
-
+    private UserCategory(
+        @NonNull User user,
+        @NonNull Category category
+    ) {
+        this.user = user;
         this.category = category;
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/user/dto/response/UserProfileResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,16 @@
+package com.civilwar.boardsignal.user.dto.response;
+
+import java.util.List;
+
+public record UserProfileResponse(
+    String nickname,
+    int signal,
+    List<String> preferCategories,
+    String gender,
+    String ageGroup,
+    String profileImageUrl,
+    double mannerScore,
+    List<UserReviewResponse> reviews
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/user/dto/response/UserReviewResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/dto/response/UserReviewResponse.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.user.dto.response;
+
+public record UserReviewResponse(
+    String content,
+    int score
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/user/facade/UserReviewFacade.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/facade/UserReviewFacade.java
@@ -34,13 +34,14 @@ public class UserReviewFacade {
         ReviewContent[] allContents = ReviewContent.values();
         for (ReviewContent content : allContents) {
 
-            //4. 유저에 대한 각 항목의 좋아요 & 싫어요 합계 계산
+            //4. 유저에 대한 각 항목의 좋아요 합계 계산
             int totalScore = userEvaluations.stream()
                 .filter(evaluation -> evaluation.getContent().equals(content))
                 .mapToInt(ReviewEvaluation::getIsRecommended)
+                .filter(isRecommended -> isRecommended==1)
                 .sum();
 
-            //. 정리된 리뷰 & 데이터 저장
+            //5. 정리된 리뷰 & 데이터 저장
             result.add(new UserReviewResponse(content.getDescription(), totalScore));
         }
 

--- a/core/src/main/java/com/civilwar/boardsignal/user/facade/UserReviewFacade.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/facade/UserReviewFacade.java
@@ -1,0 +1,50 @@
+package com.civilwar.boardsignal.user.facade;
+
+import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
+import com.civilwar.boardsignal.user.dto.response.UserReviewResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserReviewFacade {
+
+    private final ReviewRepository reviewRepository;
+
+    public List<UserReviewResponse> getUserReview(Long userId) {
+
+        //1. 유저에 대한 리뷰 조회
+        List<Review> reviews = reviewRepository.findReviewsByRevieweeId(userId);
+
+        //2. 리뷰 평가 모두 한 곳에 저장
+        List<ReviewEvaluation> userEvaluations = new ArrayList<>();
+        for (Review review : reviews) {
+            userEvaluations.addAll(review.getReviewEvaluations());
+        }
+
+        //리뷰 조회 결과를 저장할 리스트
+        List<UserReviewResponse> result = new ArrayList<>();
+
+        //3. 리뷰 항목 만큼 반복문
+        ReviewContent[] allContents = ReviewContent.values();
+        for (ReviewContent content : allContents) {
+
+            //4. 유저에 대한 각 항목의 좋아요 & 싫어요 합계 계산
+            int totalScore = userEvaluations.stream()
+                .filter(evaluation -> evaluation.getContent().equals(content))
+                .mapToInt(ReviewEvaluation::getIsRecommended)
+                .sum();
+
+            //. 정리된 리뷰 & 데이터 저장
+            result.add(new UserReviewResponse(content.getDescription(), totalScore));
+        }
+
+        return result;
+    }
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
@@ -4,13 +4,32 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.dto.response.UserModifyResponse;
+import com.civilwar.boardsignal.user.dto.response.UserProfileResponse;
+import com.civilwar.boardsignal.user.dto.response.UserReviewResponse;
+import java.util.List;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
-public class UserMapper {
+public final class UserMapper {
 
     public static UserModifyResponse toUserModifyResponse(User user) {
         return new UserModifyResponse(user.getId());
+    }
+
+    public static UserProfileResponse toUserProfileResponse(User user,
+        List<UserReviewResponse> reviews) {
+        return new UserProfileResponse(
+            user.getNickname(),
+            user.getSignal(),
+            user.getUserCategories().stream()
+                .map(userCategory -> userCategory.getCategory().getDescription())
+                .toList(),
+            user.getGender().getDescription(),
+            user.getAgeGroup().getDescription(),
+            user.getProfileImageUrl(),
+            user.getMannerScore(),
+            reviews
+        );
     }
 
 }

--- a/core/src/test/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepositoryTest.java
@@ -22,7 +22,7 @@ class ReviewJpaRepositoryTest extends DataJpaTestSupport {
     private ReviewJpaRepository reviewJpaRepository;
 
     @Test
-    @DisplayName("[사용자가 받은 리뷰 별 평가를 갖고온다 (쿼리 확인용)]")
+    @DisplayName("[사용자가 받은 리뷰 별 평가를 갖고온다]")
     void findReviewsByRevieweeIdTest() {
 
         //given

--- a/core/src/test/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.civilwar.boardsignal.review.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.civilwar.boardsignal.common.support.DataJpaTestSupport;
+import com.civilwar.boardsignal.review.ReviewFixture;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Slf4j
+class ReviewJpaRepositoryTest extends DataJpaTestSupport {
+
+    Long reviewerId = 1L;
+    Long revieweeId = 100L;
+    Long roomId = 1L;
+    @Autowired
+    private ReviewJpaRepository reviewJpaRepository;
+
+    @Test
+    @DisplayName("[사용자가 받은 리뷰 별 평가를 갖고온다 (쿼리 확인용)]")
+    void findReviewsByRevieweeIdTest() {
+
+        //given
+        List<ReviewEvaluation> evaluations = ReviewFixture.getEvaluationFixture();
+        Review reviewFixture = ReviewFixture.getReviewFixture(reviewerId, revieweeId, roomId,
+            evaluations);
+        reviewJpaRepository.save(reviewFixture);
+
+        //when
+        List<Review> reviews = reviewJpaRepository.findReviewsByRevieweeId(revieweeId);
+
+        //then
+        assertThat(reviews.get(0)).isNotNull();
+        assertThat(reviews.get(0).getReviewEvaluations()).hasSize(3);
+
+    }
+}

--- a/core/src/test/java/com/civilwar/boardsignal/user/facade/UserReviewFacadeTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/user/facade/UserReviewFacadeTest.java
@@ -1,0 +1,57 @@
+package com.civilwar.boardsignal.user.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.civilwar.boardsignal.review.ReviewFixture;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
+import com.civilwar.boardsignal.user.dto.response.UserReviewResponse;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserReviewFacadeTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @InjectMocks
+    private UserReviewFacade userReviewFacade;
+
+    @Test
+    @DisplayName("[유저가 평가 받은 리뷰를 항목 별로 정리한 데이터로 반환한다.]")
+    void getUserReviewTest() {
+        //given
+        Long revieweeId = 100L;
+        Long roomId = 1L;
+        List<ReviewEvaluation> evaluations = ReviewFixture.getEvaluationFixture();
+        List<Review> reviews = new ArrayList<>();
+        for (long i = 0; i < 3; i++) {
+            Review reviewFixture = ReviewFixture.getReviewFixture(i, revieweeId, roomId,
+                evaluations);
+            reviews.add(reviewFixture);
+        }
+        given(reviewRepository.findReviewsByRevieweeId(revieweeId)).willReturn(reviews);
+
+        //when
+        List<UserReviewResponse> userReviews = userReviewFacade.getUserReview(revieweeId);
+
+        UserReviewResponse timeCommitmentReview = userReviews.get(0);
+        UserReviewResponse goodMannerReview = userReviews.get(1);
+        UserReviewResponse fastResponseReview = userReviews.get(2);
+
+        //then
+        assertThat(userReviews).hasSize(3);
+        assertThat(timeCommitmentReview.score()).isEqualTo(3);
+        assertThat(goodMannerReview.score()).isZero();
+        assertThat(fastResponseReview.score()).isEqualTo(-3);
+    }
+}

--- a/core/src/test/java/com/civilwar/boardsignal/user/facade/UserReviewFacadeTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/user/facade/UserReviewFacadeTest.java
@@ -52,6 +52,6 @@ class UserReviewFacadeTest {
         assertThat(userReviews).hasSize(3);
         assertThat(timeCommitmentReview.score()).isEqualTo(3);
         assertThat(goodMannerReview.score()).isZero();
-        assertThat(fastResponseReview.score()).isEqualTo(-3);
+        assertThat(fastResponseReview.score()).isZero();
     }
 }

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/review/ReviewFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/review/ReviewFixture.java
@@ -1,0 +1,45 @@
+package com.civilwar.boardsignal.review;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class ReviewFixture {
+
+    public static Review getReviewFixture(
+        Long reviewerId,
+        Long revieweeId,
+        Long roomId,
+        List<ReviewEvaluation> evaluations
+    ) {
+        return Review.of(
+            reviewerId,
+            revieweeId,
+            roomId,
+            evaluations
+        );
+    }
+
+    public static List<ReviewEvaluation> getEvaluationFixture() {
+        return List.of(
+            ReviewEvaluation.of(
+                ReviewContent.TIME_COMMITMENT,
+                1
+            ),
+            ReviewEvaluation.of(
+                ReviewContent.GOOD_MANNER,
+                0
+            ),
+            ReviewEvaluation.of(
+                ReviewContent.FAST_RESPONSE,
+                -1
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
- closed #4 
- closed #16 

### ⛏ 작업 상세 내용
- 본인 프로필 조회 API 구현
- 타인 프로필 조회 API 구현

### ✅ 중점적으로 리뷰 할 부분
- UserReviewFacade -> 리뷰 데이터를 조회하고 정리하는 로직을 해당 클래스에 따로 구분하였습니다!
- Review와 1:N으로 연결된 ReviewEvaluation을 그냥 fetch join하여 함께 불러왔습니다!

### 참고사항
- 요구사항 변경(리뷰 함께 조회)에 따라 은찬님이 구현하신 코드 (#9)에 수정하려 하였는데, conflict가 너무 많이 일어나서, 코드 참고하여 새로 pr 열었습니다..!
- commit 메시지에 설명 적어놓았습니다!