### PR TITLE
feat : 공략 등록 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/dto/mapper/BoardGameApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/dto/mapper/BoardGameApiMapper.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class BoardGameApiMapper {
+public final class BoardGameApiMapper {
 
     public static AddTipRequest toAddTipRequest(ApiAddTipRequest request) {
         return new AddTipRequest(request.content());

--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/dto/mapper/BoardGameApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/dto/mapper/BoardGameApiMapper.java
@@ -1,0 +1,14 @@
+package com.civilwar.boardsignal.boardgame.dto.mapper;
+
+import com.civilwar.boardsignal.boardgame.dto.request.AddTipRequest;
+import com.civilwar.boardsignal.boardgame.dto.request.ApiAddTipRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardGameApiMapper {
+
+    public static AddTipRequest toAddTipRequest(ApiAddTipRequest request) {
+        return new AddTipRequest(request.content());
+    }
+}

--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/dto/request/ApiAddTipRequest.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/dto/request/ApiAddTipRequest.java
@@ -1,0 +1,5 @@
+package com.civilwar.boardsignal.boardgame.dto.request;
+
+public record ApiAddTipRequest(String content) {
+
+}

--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -33,10 +33,11 @@ public class BoardGameController {
 
     private final BoardGameService boardGameService;
 
+    @Operation(summary = "보드게임 목록 조회 API")
     @ApiResponse(useReturnTypeSchema = true)
     @GetMapping
     public ResponseEntity<BoardGamePageResponse<GetAllBoardGamesResponse>> getAllBoardGames(
-        @Parameter(hidden = true) BoardGameSearchCondition condition,
+        BoardGameSearchCondition condition,
         Pageable pageable
     ) {
         BoardGamePageResponse<GetAllBoardGamesResponse> boardGames = boardGameService.getAllBoardGames(
@@ -48,6 +49,7 @@ public class BoardGameController {
     @ApiResponse(useReturnTypeSchema = true)
     @PostMapping("/wish/{boardGameId}")
     public ResponseEntity<WishBoardGameResponse> wishBoardGame(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal User user,
         @PathVariable("boardGameId") Long boardGameId
     ) {
@@ -59,6 +61,7 @@ public class BoardGameController {
     @ApiResponse(useReturnTypeSchema = true)
     @PostMapping("/tip/{boardGameId}")
     public ResponseEntity<AddTipResposne> addTip(
+        @Parameter(hidden = true)
         @AuthenticationPrincipal User user,
         @PathVariable("boardGameId") Long boardGameId,
         @RequestBody ApiAddTipRequest request

--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -1,7 +1,11 @@
 package com.civilwar.boardsignal.boardgame.presentation;
 
 import com.civilwar.boardsignal.boardgame.application.BoardGameService;
+import com.civilwar.boardsignal.boardgame.dto.mapper.BoardGameApiMapper;
+import com.civilwar.boardsignal.boardgame.dto.request.AddTipRequest;
+import com.civilwar.boardsignal.boardgame.dto.request.ApiAddTipRequest;
 import com.civilwar.boardsignal.boardgame.dto.request.BoardGameSearchCondition;
+import com.civilwar.boardsignal.boardgame.dto.response.AddTipResposne;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.WishBoardGameResponse;
@@ -17,6 +21,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,4 +55,16 @@ public class BoardGameController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "보드게임 공략 등록 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/tip/{boardGameId}")
+    public ResponseEntity<AddTipResposne> addTip(
+        @AuthenticationPrincipal User user,
+        @PathVariable("boardGameId") Long boardGameId,
+        @RequestBody ApiAddTipRequest request
+    ) {
+        AddTipRequest addTipRequest = BoardGameApiMapper.toAddTipRequest(request);
+        AddTipResposne response = boardGameService.addTip(user, boardGameId, addTipRequest);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
@@ -8,6 +8,7 @@ import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGameCategory;
 import com.civilwar.boardsignal.boardgame.domain.repository.BoardGameRepository;
+import com.civilwar.boardsignal.boardgame.dto.request.ApiAddTipRequest;
 import com.civilwar.boardsignal.common.support.ApiTestSupport;
 import com.civilwar.boardsignal.fixture.BoardGameFixture;
 import java.util.List;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -88,6 +90,20 @@ class BoardGameControllerTest extends ApiTestSupport {
                 .header(AUTHORIZATION, accessToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.wishCount").value(prevWishCount));
+    }
+
+    @Test
+    @DisplayName("[사용자는 보드게임에 공략을 추가할 수 있다.]")
+    void addTip() throws Exception {
+        ApiAddTipRequest request = new ApiAddTipRequest("꿀팁입니다.");
+
+        mockMvc.perform(MockMvcRequestBuilders.post(
+                    "/api/v1/board-games/tip/{boardGameId}", boardGame1.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request))
+                .header(AUTHORIZATION, accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").value(request.content()));
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
@@ -1,5 +1,8 @@
 package com.civilwar.boardsignal.boardgame.application;
 
+import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.AlREADY_TIP_ADDED;
+import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
 import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
@@ -13,7 +16,6 @@ import com.civilwar.boardsignal.boardgame.dto.response.AddTipResposne;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.WishBoardGameResponse;
-import com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode;
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import com.civilwar.boardsignal.common.exception.ValidationException;
 import com.civilwar.boardsignal.user.domain.entity.User;
@@ -34,7 +36,7 @@ public class BoardGameService {
     private void validateTipExists(User user) { // 이미 공략을 등록한 적이 있는 지 검증
         tipRepository.findByUserId(user.getId())
             .ifPresent(tip -> {
-                throw new ValidationException(BoardGameErrorCode.AlREADY_TIP_ADDED);
+                throw new ValidationException(AlREADY_TIP_ADDED);
             });
     }
 
@@ -52,7 +54,7 @@ public class BoardGameService {
     public WishBoardGameResponse wishBoardGame(User user, Long boardGameId) {
         BoardGame boardGame = boardGameQueryRepository.findById(boardGameId)
             .orElseThrow(
-                () -> new NotFoundException(BoardGameErrorCode.NOT_FOUND_BOARD_GAME)
+                () -> new NotFoundException(NOT_FOUND_BOARD_GAME)
             );
 
         wishRepository.findByUserIdAndBoardGameId(user.getId(), boardGameId)

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
@@ -1,21 +1,27 @@
 package com.civilwar.boardsignal.boardgame.application;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
+import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
 import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import com.civilwar.boardsignal.boardgame.domain.repository.BoardGameQueryRepository;
+import com.civilwar.boardsignal.boardgame.domain.repository.TipRepository;
 import com.civilwar.boardsignal.boardgame.domain.repository.WishRepository;
 import com.civilwar.boardsignal.boardgame.dto.BoardGameMapper;
+import com.civilwar.boardsignal.boardgame.dto.request.AddTipRequest;
 import com.civilwar.boardsignal.boardgame.dto.request.BoardGameSearchCondition;
+import com.civilwar.boardsignal.boardgame.dto.response.AddTipResposne;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.WishBoardGameResponse;
 import com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode;
 import com.civilwar.boardsignal.common.exception.NotFoundException;
+import com.civilwar.boardsignal.common.exception.ValidationException;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +29,14 @@ public class BoardGameService {
 
     private final BoardGameQueryRepository boardGameQueryRepository;
     private final WishRepository wishRepository;
+    private final TipRepository tipRepository;
+
+    private void validateTipExists(User user) { // 이미 공략을 등록한 적이 있는 지 검증
+        tipRepository.findByUserId(user.getId())
+            .ifPresent(tip -> {
+                throw new ValidationException(BoardGameErrorCode.AlREADY_TIP_ADDED);
+            });
+    }
 
     public BoardGamePageResponse<GetAllBoardGamesResponse> getAllBoardGames(
         BoardGameSearchCondition condition, Pageable pageable) {
@@ -34,6 +48,7 @@ public class BoardGameService {
         return BoardGameMapper.toBoardGamePageRepsonse(findBoardGames); // 커스텀 페이징 응답 dto에 담음
     }
 
+    @Transactional
     public WishBoardGameResponse wishBoardGame(User user, Long boardGameId) {
         BoardGame boardGame = boardGameQueryRepository.findById(boardGameId)
             .orElseThrow(
@@ -53,5 +68,20 @@ public class BoardGameService {
                 }
             );
         return new WishBoardGameResponse(boardGame.getWishCount());
+    }
+
+    @Transactional
+    public AddTipResposne addTip(
+        User user,
+        Long boardGameId,
+        AddTipRequest request
+    ) {
+        validateTipExists(user);
+
+        Tip tip = Tip.of(boardGameId, user.getId(), request.content());
+
+        Tip savedTip = tipRepository.save(tip);
+
+        return new AddTipResposne(savedTip.getContent());
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Tip.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Tip.java
@@ -6,8 +6,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -25,4 +28,27 @@ public class Tip {
     private Long userId;
 
     private String content;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Tip(
+        @NonNull Long boardGameId,
+        @NonNull Long userId,
+        @NonNull String content
+    ) {
+        this.boardGameId = boardGameId;
+        this.userId = userId;
+        this.content = content;
+    }
+
+    public static Tip of(
+        Long boardGameId,
+        Long userId,
+        String content
+    ) {
+        return Tip.builder()
+            .boardGameId(boardGameId)
+            .userId(userId)
+            .content(content)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/TipRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/TipRepository.java
@@ -1,0 +1,15 @@
+package com.civilwar.boardsignal.boardgame.domain.repository;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
+import java.util.Collection;
+import java.util.Optional;
+
+public interface TipRepository {
+
+    Optional<Tip> findByUserId(Long userId);
+
+    Tip save(Tip tip);
+
+    void saveAll(Collection<Tip> tips);
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/BoardGameMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/BoardGameMapper.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class BoardGameMapper {
+public final class BoardGameMapper {
 
     public static GetAllBoardGamesResponse toGetAllBoardGamesResponse(BoardGame boardGame) {
         List<String> boardGameCategories = boardGame.getCategories().stream()

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/request/AddTipRequest.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/request/AddTipRequest.java
@@ -1,0 +1,5 @@
+package com.civilwar.boardsignal.boardgame.dto.request;
+
+public record AddTipRequest(String content) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/AddTipResposne.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/AddTipResposne.java
@@ -1,0 +1,5 @@
+package com.civilwar.boardsignal.boardgame.dto.response;
+
+public record AddTipResposne(String content) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
@@ -10,7 +10,8 @@ public enum BoardGameErrorCode implements ErrorCode {
 
 
     NOT_FOUND_BOARD_GAME("존재하지 않는 보드게임입니다", "B_001"),
-    NOT_FOUND_DIFFICULTY("존재하지 않는 난이도입니다.", "B_002");
+    NOT_FOUND_DIFFICULTY("존재하지 않는 난이도입니다.", "B_002"),
+    AlREADY_TIP_ADDED("이미 등록한 공략이 있는 보드게임입니다.", "B_003");
 
     private final String message;
     private final String code;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/TipRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/TipRepositoryAdaptor.java
@@ -1,0 +1,31 @@
+package com.civilwar.boardsignal.boardgame.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
+import com.civilwar.boardsignal.boardgame.domain.repository.TipRepository;
+import com.civilwar.boardsignal.boardgame.infrastructure.repository.TipJpaRepository;
+import java.util.Collection;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TipRepositoryAdaptor implements TipRepository {
+
+    private final TipJpaRepository tipJpaRepository;
+
+    @Override
+    public Optional<Tip> findByUserId(Long userId) {
+        return tipJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Tip save(Tip tip) {
+        return tipJpaRepository.save(tip);
+    }
+
+    @Override
+    public void saveAll(Collection<Tip> tips) {
+        tipJpaRepository.saveAll(tips);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/TipJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/TipJpaRepository.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.boardgame.infrastructure.repository;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipJpaRepository extends JpaRepository<Tip, Long> {
+
+    Optional<Tip> findByUserId(Long userId);
+}

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/fixture/BoardGameFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/fixture/BoardGameFixture.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.boardgame.domain.constant.Difficulty;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGameCategory;
+import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
 import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import java.util.List;
 import lombok.AccessLevel;
@@ -48,5 +49,9 @@ public class BoardGameFixture {
 
     public static Wish getWish(Long userId, Long boardGameId) {
         return Wish.of(userId, boardGameId);
+    }
+
+    public static Tip getTip(Long userId, Long boardGameId, String content) {
+        return Tip.of(userId, boardGameId, content);
     }
 }


### PR DESCRIPTION
- closed #24 

### ⛏ 작업 상세 내용

- 공략 등록 API 구현 및 테스트
    - 요청으로 온 보드게임에 대해 사용자가 이미 등록된 공략이 있다면 예외 발생
    - 등록된 공략이 없다면 공략 등록

### ✅ 중점적으로 리뷰 할 부분

- 비즈니스 로직
- 테스트 코드 추가할 부분 & 테스트 로직

### 참고사항
