### PR TITLE
feat : 보드게임 검색 기능 구현

### DIFF
--- a/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
@@ -116,26 +116,28 @@ class BoardGameControllerTest extends ApiTestSupport {
         params.add("searchKeyword", boardGame1.getTitle().substring(0, 1));
         mockMvc.perform(get("/api/v1/board-games")
                 .params(params))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.boardGamesInfos[0].name")
-                .value(boardGame1.getTitle()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].categories[0]")
-                .value(boardGame2.getCategories().get(0).getCategory().getDescription()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].difficulty")
-                .value(boardGame1.getDifficulty().getDescription()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].minParticipants")
-                .value(boardGame1.getMinParticipants()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].maxParticipants")
-                .value(boardGame1.getMaxParticipants()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].fromPlayTime")
-                .value(boardGame1.getFromPlayTime()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].toPlayTime")
-                .value(boardGame1.getToPlayTime()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].wishCount")
-                .value(boardGame1.getWishCount()))
-            .andExpect(jsonPath("$.boardGamesInfos[0].imageUrl")
-                .value(boardGame1.getMainImageUrl()))
-            .andExpect(jsonPath("$.size").value(1))
-            .andExpect(jsonPath("$.hasNext").value(false));
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.boardGamesInfos[0].name")
+                    .value(boardGame1.getTitle()),
+                jsonPath("$.boardGamesInfos[0].categories[0]")
+                    .value(boardGame2.getCategories().get(0).getCategory().getDescription()),
+                jsonPath("$.boardGamesInfos[0].difficulty")
+                    .value(boardGame1.getDifficulty().getDescription()),
+                jsonPath("$.boardGamesInfos[0].minParticipants")
+                    .value(boardGame1.getMinParticipants()),
+                jsonPath("$.boardGamesInfos[0].maxParticipants")
+                    .value(boardGame1.getMaxParticipants()),
+                jsonPath("$.boardGamesInfos[0].fromPlayTime")
+                    .value(boardGame1.getFromPlayTime()),
+                jsonPath("$.boardGamesInfos[0].toPlayTime")
+                    .value(boardGame1.getToPlayTime()),
+                jsonPath("$.boardGamesInfos[0].wishCount")
+                    .value(boardGame1.getWishCount()),
+                jsonPath("$.boardGamesInfos[0].imageUrl")
+                    .value(boardGame1.getMainImageUrl()),
+                jsonPath("$.size").value(1),
+                jsonPath("$.hasNext").value(false)
+            );
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.user.presentation;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -24,7 +24,6 @@ import com.civilwar.boardsignal.user.dto.request.ApiUserModifyRequest;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/request/BoardGameSearchCondition.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/request/BoardGameSearchCondition.java
@@ -5,7 +5,8 @@ import java.util.List;
 public record BoardGameSearchCondition(
     String difficulty,
     List<String> categories,
-    Integer playTime
+    Integer playTime,
+    String searchKeyword
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptor.java
@@ -58,6 +58,14 @@ public class BoardGameQueryRepositoryAdaptor implements BoardGameQueryRepository
         return boardGameCategory.category.in(categoryList);
     }
 
+    private BooleanExpression containsKeyword(String searchKeyword) {
+        if (!hasText(searchKeyword)) {
+            return null;
+        }
+        return boardGame.title.contains(searchKeyword)
+            .or(boardGame.description.contains(searchKeyword));
+    }
+
     @Override
     public Optional<BoardGame> findById(Long id) {
         return boardGameJpaRepository.findById(id);
@@ -72,7 +80,8 @@ public class BoardGameQueryRepositoryAdaptor implements BoardGameQueryRepository
             .where(
                 equalDifficulty(condition.difficulty()),
                 checkRangePlayTime(condition.playTime()),
-                containsCategory(condition.categories())
+                containsCategory(condition.categories()),
+                containsKeyword(condition.searchKeyword())
             )
             .from(boardGame)
             .join(boardGame.categories, boardGameCategory)

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/ReviewEvaluation.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/entity/ReviewEvaluation.java
@@ -1,7 +1,7 @@
 package com.civilwar.boardsignal.review.domain.entity;
 
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
-import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.EnumType.STRING;
 
 import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
 import jakarta.persistence.Column;

--- a/core/src/main/java/com/civilwar/boardsignal/user/facade/UserReviewFacade.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/facade/UserReviewFacade.java
@@ -38,7 +38,7 @@ public class UserReviewFacade {
             int totalScore = userEvaluations.stream()
                 .filter(evaluation -> evaluation.getContent().equals(content))
                 .mapToInt(ReviewEvaluation::getIsRecommended)
-                .filter(isRecommended -> isRecommended==1)
+                .filter(isRecommended -> isRecommended == 1)
                 .sum();
 
             //5. 정리된 리뷰 & 데이터 저장

--- a/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameServiceTest.java
@@ -69,6 +69,7 @@ class BoardGameServiceTest {
             "보통",
             List.of(),
             null
+            , null
         );
 
         PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
@@ -108,6 +109,7 @@ class BoardGameServiceTest {
             "어려움",
             List.of(),
             null
+            , null
         );
 
         PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
@@ -239,5 +241,53 @@ class BoardGameServiceTest {
             .isInstanceOf(ValidationException.class)
             .hasMessageContaining(BoardGameErrorCode.AlREADY_TIP_ADDED.getMessage());
     }
+
+    @Test
+    @DisplayName("[사용자는 검색 키워드를 통해 보드게임을 검색할 수 있다.]")
+    void searchWithKeyword() {
+        BoardGameCategory warGame = BoardGameFixture.getBoardGameCategory(WAR);
+        BoardGameCategory familyGame = BoardGameFixture.getBoardGameCategory(FAMILY);
+        BoardGame boardGame = BoardGameFixture.getBoardGame(List.of(warGame, familyGame));
+
+        BoardGameSearchCondition condition = new BoardGameSearchCondition(
+            null,
+            null,
+            null
+            , String.valueOf(boardGame.getTitle().charAt(0))
+        );
+
+        PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
+
+        given(boardGameQueryRepository.findAll(condition, pageRequest))
+            .willReturn(new PageImpl<>(List.of(boardGame)));
+
+        BoardGamePageResponse<GetAllBoardGamesResponse> boardGames = boardGameService.getAllBoardGames(
+            condition,
+            pageRequest
+        );
+        GetAllBoardGamesResponse findBoardGame = boardGames.boardGamesInfos().get(0);
+
+        assertAll(
+            () -> assertThat(findBoardGame.name())
+                .isEqualTo(boardGame.getTitle()),
+            () -> assertThat(findBoardGame.categories())
+                .hasSameSizeAs(boardGame.getCategories()),
+            () -> assertThat(findBoardGame.difficulty())
+                .isEqualTo(boardGame.getDifficulty().getDescription()),
+            () -> assertThat(findBoardGame.minParticipants())
+                .isEqualTo(boardGame.getMinParticipants()),
+            () -> assertThat(findBoardGame.maxParticipants())
+                .isEqualTo(boardGame.getMaxParticipants()),
+            () -> assertThat(findBoardGame.fromPlayTime())
+                .isEqualTo(boardGame.getFromPlayTime()),
+            () -> assertThat(findBoardGame.toPlayTime())
+                .isEqualTo(boardGame.getToPlayTime()),
+            () -> assertThat(findBoardGame.wishCount())
+                .isEqualTo(boardGame.getWishCount()),
+            () -> assertThat(findBoardGame.imageUrl())
+                .isEqualTo(boardGame.getMainImageUrl())
+        );
+    }
+
 
 }


### PR DESCRIPTION
- closed #28 

### ⛏ 작업 상세 내용

- 보드게임 검색 기능 추가
- 기존 보드게임 필터링 전체조회에 검색 키워드를 통한 조건 파라미터 추가
- api 따로 추가하진 않음

### ✅ 중점적으로 리뷰 할 부분

- 사실 기존 구현에 필터링 조건 하나 더 추가한거라 테스트 코드 위주로 보시면 될 것 같습니다

### 참고사항
