### PR TITLE
feat : 사용자는 참여했던 모임들을 조회할 수 있다 

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -9,6 +9,7 @@ import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -35,7 +36,7 @@ public class RoomController {
     @ApiResponse(useReturnTypeSchema = true)
     @PostMapping
     public ResponseEntity<CreateRoomResponse> createRoom(
-        @AuthenticationPrincipal User user,
+        @Parameter(hidden = true) @AuthenticationPrincipal User user,
         @RequestPart(value = "image", required = false) MultipartFile image,
         @Valid @RequestPart(value = "data") ApiCreateRoomRequest request
     ) {
@@ -50,7 +51,7 @@ public class RoomController {
     @ApiResponse(useReturnTypeSchema = true)
     @GetMapping("/my/end-games")
     public ResponseEntity<RoomPageResponse<GetAllRoomResponse>> getMyEndGame(
-        @AuthenticationPrincipal User user,
+        @Parameter(hidden = true) @AuthenticationPrincipal User user,
         Pageable pageable
     ) {
 

--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -5,14 +5,18 @@ import com.civilwar.boardsignal.room.dto.mapper.RoomApiMapper;
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -40,5 +44,19 @@ public class RoomController {
         CreateRoomResponse createRoomResponse = roomService.createRoom(user, createRoomRequest);
 
         return ResponseEntity.ok(createRoomResponse);
+    }
+
+    @Operation(summary = "내가 이전에 참여한 모임 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/my/end-games")
+    public ResponseEntity<RoomPageResponse<GetAllRoomResponse>> getMyEndGame(
+        @AuthenticationPrincipal User user,
+        Pageable pageable
+    ) {
+
+        RoomPageResponse<GetAllRoomResponse> myParticipants = roomService.findMyEndGame(
+            user.getId(), pageable);
+
+        return ResponseEntity.ok(myParticipants);
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
@@ -157,6 +157,7 @@ class BoardGameControllerTest extends ApiTestSupport {
                 jsonPath("$.hasNext").value(false)
             );
     }
+
     @Test
     @DisplayName("[사용자는 보드게임 상세정보를 조회할 수 있다]")
     void getBoardGame() throws Exception {

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -114,7 +114,7 @@ class RoomControllerTest extends ApiTestSupport {
             //모임 확정
             MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(before);
             meetingInfoRepository.save(meetingInfo);
-            room.updateMeetingInfo(meetingInfo);
+            room.fixRoom(meetingInfo);
             roomRepository.save(room);
         }
 
@@ -150,7 +150,7 @@ class RoomControllerTest extends ApiTestSupport {
             //모임 확정
             MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(after);
             meetingInfoRepository.save(meetingInfo);
-            room.updateMeetingInfo(meetingInfo);
+            room.fixRoom(meetingInfo);
             roomRepository.save(room);
         }
 

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -1,30 +1,49 @@
 package com.civilwar.boardsignal.room.presentation;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.civilwar.boardsignal.common.support.ApiTestSupport;
+import com.civilwar.boardsignal.room.MeetingInfoFixture;
+import com.civilwar.boardsignal.room.RoomFixture;
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
+import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
+import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 @DisplayName("[RoomController 테스트]")
 class RoomControllerTest extends ApiTestSupport {
 
     @Autowired
     private RoomRepository roomRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private MeetingInfoJpaRepository meetingInfoRepository;
+    @MockBean
+    private Supplier<LocalDateTime> nowTime;
 
     @Test
     @DisplayName("[사용자는 방을 생성할 수 있다.]")
@@ -71,6 +90,90 @@ class RoomControllerTest extends ApiTestSupport {
         Room room = roomRepository.findById(1L).orElseThrow();
 
         resultActions.andExpect(jsonPath("$.roomId").value(room.getId()));
+
+    }
+
+    @Test
+    @DisplayName("[사용자는 자신이 참여했던 모임을 조회할 수 있다.]")
+    void getMyEndGameTest() throws Exception {
+        //given
+        LocalDateTime now = LocalDateTime.of(2024, 2, 21, 20, 0, 0);
+        LocalDateTime before = LocalDateTime.of(2024, 2, 20, 20, 0, 0);
+        given(nowTime.get()).willReturn(now);
+
+        //방 생성
+        for (int i = 0; i < 6; i++) {
+            //방 생성
+            Room room = RoomFixture.getRoom();
+            roomRepository.save(room);
+
+            //방 참가
+            Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
+            participantRepository.save(participant);
+
+            //모임 확정
+            MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(before);
+            meetingInfoRepository.save(meetingInfo);
+            room.updateMeetingInfo(meetingInfo);
+            roomRepository.save(room);
+        }
+
+        //then
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("size", "5");
+        mockMvc.perform(get("/api/v1/rooms/my/end-games")
+                .header(AUTHORIZATION, accessToken)
+                .params(params))
+            .andExpect(jsonPath("$.size").value(5))
+            .andExpect(jsonPath("$.hasNext").value(true))
+            .andExpect(jsonPath("$.roomsInfos.length()").value(5));
+    }
+
+    @Test
+    @DisplayName("[사용자의 non-fix 모임, 확정 시간이 지나지 않은 모임은 불러오지 않는다]")
+    void getMyEndGameTest2() throws Exception {
+        //given
+        LocalDateTime now = LocalDateTime.of(2024, 2, 21, 20, 0, 0);
+        LocalDateTime after = LocalDateTime.of(2024, 2, 22, 20, 0, 0);
+        given(nowTime.get()).willReturn(now);
+
+        //모임 확정 시간이 아직 지나지 않은 방 생성
+        for (int i = 0; i < 5; i++) {
+            //방 생성
+            Room room = RoomFixture.getRoom();
+            roomRepository.save(room);
+
+            //방 참가
+            Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
+            participantRepository.save(participant);
+
+            //모임 확정
+            MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(after);
+            meetingInfoRepository.save(meetingInfo);
+            room.updateMeetingInfo(meetingInfo);
+            roomRepository.save(room);
+        }
+
+        //non-fix 방 생성
+        for (int i = 0; i < 5; i++) {
+            //방 생성
+            Room room = RoomFixture.getRoom();
+            roomRepository.save(room);
+
+            //방 참가
+            Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
+            participantRepository.save(participant);
+        }
+
+        //then
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("size", "100");
+        mockMvc.perform(get("/api/v1/rooms/my/end-games")
+                .header(AUTHORIZATION, accessToken)
+                .params(params))
+            .andExpect(jsonPath("$.size").value(100))
+            .andExpect(jsonPath("$.hasNext").value(false))
+            .andExpect(jsonPath("$.roomsInfos.length()").value(0));
 
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-security'
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
 
     //테스트 픽쳐에서 사용할 의존성
     testFixturesImplementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'

--- a/core/src/main/java/com/civilwar/boardsignal/common/config/QueryDslConfig.java
+++ b/core/src/main/java/com/civilwar/boardsignal/common/config/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package com.civilwar.boardsignal.common.configuratrion;
+package com.civilwar.boardsignal.common.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/core/src/main/java/com/civilwar/boardsignal/common/config/TimeConfig.java
+++ b/core/src/main/java/com/civilwar/boardsignal/common/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.civilwar.boardsignal.common.config;
+
+import java.time.LocalDateTime;
+import java.util.function.Supplier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean("nowLocalDateTimeSupplier")
+    public Supplier<LocalDateTime> nowLocalDateTimeSupplier() {
+        return LocalDateTime::now;
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -1,7 +1,6 @@
 package com.civilwar.boardsignal.room.application;
 
 import com.civilwar.boardsignal.image.domain.ImageRepository;
-import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
@@ -55,14 +54,9 @@ public class RoomService {
         boolean hasNext = false;
 
         //1. 내가 참여한 모든 room
-        List<Room> myGame = roomRepository.findMyGame(userId);
+        List<Room> myFixGame = roomRepository.findMyFixRoom(userId);
 
-        //2. 상태가 fix인 room
-        List<Room> myFixGame = myGame.stream()
-            .filter(room -> room.getStatus().equals(RoomStatus.FIX))
-            .toList();
-
-        //3. (모임 확정 day) < 현재 day 인 room
+        //2. (모임 확정 day) < 현재 day 인 room
         List<Room> myEndGame = new ArrayList<>(
             myFixGame.stream()
                 .filter(room -> room.getMeetingInfo().getMeetingTime().toLocalDate()
@@ -70,17 +64,17 @@ public class RoomService {
                 ).toList()
         );
 
-        //4. 내가 한 게임 전체 size > 요구 size -> 다음 페이지 존재
+        //3. 내가 한 게임 전체 size > 요구 size -> 다음 페이지 존재
         if (myEndGame.size() > pageable.getPageSize()) {
             hasNext = true;
         }
 
-        //5. size 크기만큼 cut
+        //4. size 크기만큼 cut
         List<Room> resultList = myEndGame.stream()
             .limit(pageable.getPageSize())
             .toList();
 
-        //6. slice 변환
+        //5. slice 변환
         Slice<Room> result = new SliceImpl<>(resultList, pageable, hasNext);
 
         return RoomMapper.toRoomPageResponse(result);

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/MeetingInfo.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/MeetingInfo.java
@@ -7,8 +7,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -32,4 +35,35 @@ public class MeetingInfo {
     private String station;
 
     private String meetingPlace;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public MeetingInfo(
+        @NonNull LocalDateTime meetingTime,
+        @NonNull int peopleCount,
+        @NonNull String line,
+        @NonNull String station,
+        @NonNull String meetingPlace
+    ) {
+        this.meetingTime = meetingTime;
+        this.peopleCount = peopleCount;
+        this.line = line;
+        this.station = station;
+        this.meetingPlace = meetingPlace;
+    }
+
+    public static MeetingInfo of(
+        LocalDateTime meetingTime,
+        int peopleCount,
+        String line,
+        String station,
+        String meetingPlace
+    ) {
+        return MeetingInfo.builder()
+            .meetingTime(meetingTime)
+            .peopleCount(peopleCount)
+            .line(line)
+            .station(station)
+            .meetingPlace(meetingPlace)
+            .build();
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.common.base.BaseEntity;
 import com.civilwar.boardsignal.room.domain.constants.DaySlot;
 import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
 import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
@@ -31,7 +32,7 @@ import org.springframework.lang.NonNull;
 @NoArgsConstructor
 @Getter
 @Table(name = "ROOM_TABLE")
-public class Room {
+public class Room extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -88,7 +89,7 @@ public class Room {
     private MeetingInfo meetingInfo;
 
     @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private List<RoomCategory> roomCategories = new ArrayList<>();
+    private final List<RoomCategory> roomCategories = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Room(
@@ -163,5 +164,10 @@ public class Room {
             .isAllowedOppositeGender(isAllowedOppositeGender)
             .roomCategories(roomCategories)
             .build();
+    }
+
+    public void updateMeetingInfo(MeetingInfo meetingInfo) {
+        this.meetingInfo = meetingInfo;
+        this.status = RoomStatus.FIX;
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.room.domain.entity;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
+import static jakarta.persistence.EnumType.*;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.common.base.BaseEntity;
@@ -11,6 +12,7 @@ import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
 import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -52,6 +54,7 @@ public class Room extends BaseEntity {
     private int maxParticipants;
 
     @Column(name = "ROOM_STATUS")
+    @Enumerated(STRING)
     private RoomStatus status;
 
     @Column(name = "ROOM_PLACE_NAME")
@@ -64,9 +67,11 @@ public class Room extends BaseEntity {
     private String subwayStation;
 
     @Column(name = "ROOM_DAY_SLOT")
+    @Enumerated(STRING)
     private DaySlot daySlot;
 
     @Column(name = "ROOM_TIME_SLOT")
+    @Enumerated(STRING)
     private TimeSlot timeSlot;
 
     @Column(name = "ROOM_START_TIME")
@@ -166,7 +171,7 @@ public class Room extends BaseEntity {
             .build();
     }
 
-    public void updateMeetingInfo(MeetingInfo meetingInfo) {
+    public void fixRoom(MeetingInfo meetingInfo) {
         this.meetingInfo = meetingInfo;
         this.status = RoomStatus.FIX;
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/RoomCategory.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/RoomCategory.java
@@ -1,10 +1,12 @@
 package com.civilwar.boardsignal.room.domain.entity;
 
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
+import static jakarta.persistence.EnumType.STRING;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -34,6 +36,7 @@ public class RoomCategory {
     private Room room;
 
     @Column(name = "ROOM_CATEGORY_CATEGORY")
+    @Enumerated(STRING)
     private Category category;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.room.domain.repository;
 
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomRepository {
@@ -11,4 +12,6 @@ public interface RoomRepository {
     void saveAll(Collection<Room> rooms);
 
     Optional<Room> findById(Long id);
+
+    List<Room> findMyGame(Long id);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
@@ -13,5 +13,5 @@ public interface RoomRepository {
 
     Optional<Room> findById(Long id);
 
-    List<Room> findMyGame(Long id);
+    List<Room> findMyFixRoom(Long userId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -6,9 +6,12 @@ import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RoomMapper {
@@ -44,5 +47,38 @@ public final class RoomMapper {
 
     public static CreateRoomResponse toCreateRoomResponse(Room room) {
         return new CreateRoomResponse(room.getId());
+    }
+
+    public static GetAllRoomResponse toGetAllRoomResponse(Room room) {
+        List<String> categories = room.getRoomCategories().stream()
+            .map(roomCategory -> roomCategory.getCategory().getDescription())
+            .toList();
+
+        return new GetAllRoomResponse(
+            room.getId(),
+            room.getTitle(),
+            room.getDescription(),
+            room.getSubwayStation(),
+            room.getStartTime(),
+            room.getMinAge(),
+            room.getMaxAge(),
+            room.isAllowedOppositeGender(),
+            room.getImageUrl(),
+            room.getMinParticipants(),
+            room.getMaxParticipants(),
+            categories,
+            room.getCreatedAt()
+        );
+    }
+
+    public static RoomPageResponse<GetAllRoomResponse> toRoomPageResponse(Slice<Room> pages) {
+
+        Slice<GetAllRoomResponse> dto = pages.map(RoomMapper::toGetAllRoomResponse);
+
+        return new RoomPageResponse<>(
+            dto.getContent(),
+            dto.getSize(),
+            dto.hasNext()
+        );
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetAllRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetAllRoomResponse.java
@@ -1,0 +1,24 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetAllRoomResponse(
+    Long id,
+    String title,
+    String description,
+    String station,
+    String time,
+    int minAge,
+    int maxAge,
+    boolean isAllowedAppositeGender,
+    String imageUrl,
+    int minParticipants,
+    int maxParticipants,
+    List<String> categories,
+    @JsonFormat(pattern = "MM-dd")
+    LocalDateTime createdAt
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomPageResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomPageResponse.java
@@ -1,0 +1,11 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+import java.util.List;
+
+public record RoomPageResponse<T>(
+    List<T> roomsInfos,
+    int size,
+    boolean hasNext
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.infrastructure.repository.RoomJpaRepository;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -27,5 +28,10 @@ public class RoomRepositoryAdaptor implements RoomRepository {
     @Override
     public Optional<Room> findById(Long id) {
         return roomJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Room> findMyGame(Long id) {
+        return roomJpaRepository.findMyGame(id);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -31,7 +31,7 @@ public class RoomRepositoryAdaptor implements RoomRepository {
     }
 
     @Override
-    public List<Room> findMyGame(Long id) {
-        return roomJpaRepository.findMyGame(id);
+    public List<Room> findMyFixRoom(Long userId) {
+        return roomJpaRepository.findMyFixRoom(userId);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/MeetingInfoJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/MeetingInfoJpaRepository.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.room.infrastructure.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingInfoJpaRepository extends JpaRepository<MeetingInfo, Long> {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -1,8 +1,21 @@
 package com.civilwar.boardsignal.room.infrastructure.repository;
 
 import com.civilwar.boardsignal.room.domain.entity.Room;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomJpaRepository extends JpaRepository<Room, Long> {
+
+    // 내가 참여한 모든 room 조회 쿼리
+    @EntityGraph(attributePaths = {"roomCategories", "meetingInfo"})
+    @Query("select r "
+        + "from Room as r "
+        + "join Participant as p "
+        + "on r.id = p.roomId "
+        + "where p.userId=:userId ")
+    List<Room> findMyGame(@Param("userId") Long id);
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -15,7 +15,8 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
         + "from Room as r "
         + "join Participant as p "
         + "on r.id = p.roomId "
-        + "where p.userId=:userId ")
-    List<Room> findMyGame(@Param("userId") Long id);
+        + "where p.userId=:userId "
+        + "and r.status='FIX'")
+    List<Room> findMyFixRoom(@Param("userId") Long userId);
 
 }

--- a/core/src/test/java/com/civilwar/boardsignal/common/support/DataJpaTestSupport.java
+++ b/core/src/test/java/com/civilwar/boardsignal/common/support/DataJpaTestSupport.java
@@ -3,7 +3,7 @@ package com.civilwar.boardsignal.common.support;
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
 import com.civilwar.boardsignal.common.config.TestAuditingConfig;
-import com.civilwar.boardsignal.common.configuratrion.QueryDslConfig;
+import com.civilwar.boardsignal.common.config.QueryDslConfig;
 import com.civilwar.boardsignal.support.DatabaseCleaner;
 import com.civilwar.boardsignal.support.DatabaseCleanerExtension;
 import com.civilwar.boardsignal.support.TestContainerSupport;

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -74,33 +74,6 @@ class RoomServiceTest {
         assertThat(response.roomId()).isEqualTo(room.getId());
     }
 
-
-    @Test
-    @DisplayName("[자신이 참여한 방 중 non-fix 방은 보여주지 않는다.]")
-    void findMyEndGameTest() throws IOException {
-        //given
-        Long userId = 1L;
-        int PAGE_NUMBER = 0;
-        int PAGE_SIZE = 5;
-        PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
-
-        //non-fix인 방 -> 30개 저장
-        List<Room> testResult = new ArrayList<>();
-        for (int i = 0; i < 30; i++) {
-            Room room = RoomFixture.getRoom();
-            ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
-            testResult.add(room);
-        }
-        given(roomRepository.findMyGame(userId)).willReturn(testResult);
-
-        //when
-        RoomPageResponse<GetAllRoomResponse> myEndGame = roomService.findMyEndGame(userId,
-            pageRequest);
-
-        //then
-        assertThat(myEndGame.roomsInfos()).isEmpty();
-    }
-
     @Test
     @DisplayName("[자신이 참여한 fix 방 중 모임 확정 시간이 지난 방을 보여준다.]")
     void findMyEndGameTest2() throws IOException {
@@ -121,7 +94,7 @@ class RoomServiceTest {
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
-        given(roomRepository.findMyGame(userId)).willReturn(testResult);
+        given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
         //when
         RoomPageResponse<GetAllRoomResponse> myEndGame = roomService.findMyEndGame(userId,
@@ -152,7 +125,7 @@ class RoomServiceTest {
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
-        given(roomRepository.findMyGame(userId)).willReturn(testResult);
+        given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
         //when
         RoomPageResponse<GetAllRoomResponse> myEndGame = roomService.findMyEndGame(userId,
@@ -183,7 +156,7 @@ class RoomServiceTest {
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
-        given(roomRepository.findMyGame(userId)).willReturn(testResult);
+        given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
         //when
         RoomPageResponse<GetAllRoomResponse> myEndGame = roomService.findMyEndGame(userId,
@@ -214,7 +187,7 @@ class RoomServiceTest {
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
-        given(roomRepository.findMyGame(userId)).willReturn(testResult);
+        given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
         //when
         RoomPageResponse<GetAllRoomResponse> myEndGame = roomService.findMyEndGame(userId,

--- a/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.civilwar.boardsignal.room.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.civilwar.boardsignal.common.support.DataJpaTestSupport;
+import com.civilwar.boardsignal.room.MeetingInfoFixture;
+import com.civilwar.boardsignal.room.RoomFixture;
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RoomJpaRepositoryTest extends DataJpaTestSupport {
+
+    @PersistenceUnit
+    EntityManagerFactory emf;
+    @Autowired
+    private RoomJpaRepository roomJpaRepository;
+    @Autowired
+    private ParticipantJpaRepository participantJpaRepository;
+    @Autowired
+    private MeetingInfoJpaRepository meetingInfoJpaRepository;
+
+    @Test
+    @DisplayName("[유저는 자신이 과거의 참여했거나, 현재 참여한 모든 room을 조회 할 수 있다]")
+    void findMyGameTest() throws IOException {
+        //given
+        Long user1 = 1L;
+        Long user2 = 2L;
+        Room room = RoomFixture.getRoom();
+        Room room2 = RoomFixture.getRoom();
+        roomJpaRepository.save(room);
+        roomJpaRepository.save(room2);
+
+        //user1 -> room1 참여
+        Participant participant = Participant.of(user1, room.getId(), true);
+        //user2 -> room2 참여
+        Participant participant2 = Participant.of(user2, room2.getId(), true);
+        //user1 -> room2 참여
+        Participant participant3 = Participant.of(user1, room2.getId(), false);
+        participantJpaRepository.save(participant);
+        participantJpaRepository.save(participant2);
+        participantJpaRepository.save(participant3);
+
+        //모임 확정
+        MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
+            LocalDateTime.of(2024, 2, 22, 19, 0, 0));
+        MeetingInfo meetingInfo2 = MeetingInfoFixture.getMeetingInfo(
+            LocalDateTime.of(2024, 2, 22, 19, 0, 0));
+        meetingInfoJpaRepository.save(meetingInfo);
+        meetingInfoJpaRepository.save(meetingInfo2);
+
+        room.updateMeetingInfo(meetingInfo);
+        room2.updateMeetingInfo(meetingInfo2);
+        roomJpaRepository.save(room);
+        roomJpaRepository.save(room2);
+
+        //when
+        List<Room> userGame1 = roomJpaRepository.findMyGame(user1);
+        List<Room> userGame2 = roomJpaRepository.findMyGame(user2);
+
+        Room room1 = userGame1.get(0);
+        //fetch loading 확인
+        boolean loaded1 = emf.getPersistenceUnitUtil().isLoaded(room1.getRoomCategories().get(0));
+        boolean loaded2 = emf.getPersistenceUnitUtil().isLoaded(room1.getMeetingInfo());
+
+        //then
+        assertThat(userGame1).hasSize(2);
+        assertThat(userGame2).hasSize(1);
+        assertThat(loaded1).isTrue();
+        assertThat(loaded2).isTrue();
+    }
+}

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/MeetingInfoFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/MeetingInfoFixture.java
@@ -1,0 +1,21 @@
+package com.civilwar.boardsignal.room;
+
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MeetingInfoFixture {
+
+    public static MeetingInfo getMeetingInfo(LocalDateTime meetingTime) {
+        return MeetingInfo.of(
+            meetingTime,
+            3,
+            "2호선",
+            "사당역",
+            "레드버튼"
+        );
+    }
+
+}

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
@@ -1,11 +1,13 @@
 package com.civilwar.boardsignal.room;
 
 import com.civilwar.boardsignal.common.MultipartFileFixture;
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.mapper.RoomMapper;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -14,6 +16,14 @@ import org.springframework.web.multipart.MultipartFile;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RoomFixture {
+
+    public static Room getRoomWithMeetingInfo(LocalDateTime meetingTime) throws IOException {
+        MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(meetingTime);
+        Room room = getRoom();
+        room.updateMeetingInfo(meetingInfo);
+
+        return room;
+    }
 
     public static Room getRoom() throws IOException {
         MockMultipartFile image = MultipartFileFixture.getMultipartFile();

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
@@ -20,7 +20,7 @@ public class RoomFixture {
     public static Room getRoomWithMeetingInfo(LocalDateTime meetingTime) throws IOException {
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(meetingTime);
         Room room = getRoom();
-        room.updateMeetingInfo(meetingInfo);
+        room.fixRoom(meetingInfo);
 
         return room;
     }


### PR DESCRIPTION
- closed #17 

### ⛏ 작업 상세 내용

- 자신이 이전에 참여했던 모임들을 조회할 수 있다
- 모임 확정 날짜 기준 자정이 지나야 해당 모임 조회

### ✅ 중점적으로 리뷰 할 부분

- RoomJpaRepository : 자신이 참여한 모든 모임 데이터들을 가져온 후,
- RoomService : 모든 모임 데이터들을 요구사항 조건에 맞게 필터링 한 후, Slice로 변환 부분

해당 흐름으로 가는데 service 로직에서 데이터를 걸러내고 slice로 변환해도 괜찮을까요? 

### 참고사항

- 2~3개의 엔티티와 엮여있기에 테스트 데이터 세팅이 살짝 그렇습니다..!
- 커밋 별로 메시지 남겼습니다
