### PR TITLE
feat : 찜 등록에 대한 동시성 이슈 제어

### DIFF
--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
@@ -58,7 +58,7 @@ public class BoardGameService {
 
     @Transactional
     public WishBoardGameResponse wishBoardGame(User user, Long boardGameId) {
-        BoardGame boardGame = boardGameQueryRepository.findById(boardGameId)
+        BoardGame boardGame = boardGameQueryRepository.findByIdWithLock(boardGameId)
             .orElseThrow(
                 () -> new NotFoundException(NOT_FOUND_BOARD_GAME)
             );

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/BoardGameQueryRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/BoardGameQueryRepository.java
@@ -12,4 +12,6 @@ public interface BoardGameQueryRepository {
 
     Slice<BoardGame> findAll(BoardGameSearchCondition condition, Pageable pageable);
 
+    Optional<BoardGame> findByIdWithLock(Long id);
+
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptor.java
@@ -96,4 +96,9 @@ public class BoardGameQueryRepositoryAdaptor implements BoardGameQueryRepository
         }
         return new SliceImpl<>(boardGames, pageable, hasNext);
     }
+
+    @Override
+    public Optional<BoardGame> findByIdWithLock(Long id) {
+        return boardGameJpaRepository.findByIdWithLock(id);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/BoardGameJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/BoardGameJpaRepository.java
@@ -1,8 +1,16 @@
 package com.civilwar.boardsignal.boardgame.infrastructure.repository;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BoardGameJpaRepository extends JpaRepository<BoardGame, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select b from BoardGame b where b.id = :id")
+    Optional<BoardGame> findByIdWithLock(@Param("id") Long id);
 }

--- a/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameConcurrencyTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameConcurrencyTest.java
@@ -1,0 +1,74 @@
+package com.civilwar.boardsignal.boardgame.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
+import com.civilwar.boardsignal.boardgame.domain.entity.BoardGameCategory;
+import com.civilwar.boardsignal.boardgame.domain.repository.BoardGameQueryRepository;
+import com.civilwar.boardsignal.boardgame.domain.repository.BoardGameRepository;
+import com.civilwar.boardsignal.fixture.BoardGameFixture;
+import com.civilwar.boardsignal.support.TestContainerSupport;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest
+class BoardGameConcurrencyTest extends TestContainerSupport {
+
+    @Autowired
+    private BoardGameService boardGameService;
+
+    @Autowired
+    private BoardGameRepository boardGameRepository;
+
+    @Autowired
+    private BoardGameQueryRepository boardGameQueryRepository;
+
+    @Test
+    @DisplayName("[동시에 50의 사용자가 한 게임에 찜 등록을 하면 50개의 찜등록이 된다.]")
+    void addTipWithConcurrency() throws InterruptedException {
+        int threadCount = 50;
+
+        BoardGameCategory warGame = BoardGameFixture.getBoardGameCategory(Category.WAR);
+        BoardGame boardGame = BoardGameFixture.getBoardGame(List.of(warGame));
+        BoardGame savedGame = boardGameRepository.save(boardGame);
+
+        List<User> users = new ArrayList<>();
+        for (int i = 1; i <= threadCount; i++) {
+            User user = UserFixture.getUserFixture(String.valueOf(i), "httips~~");
+            ReflectionTestUtils.setField(user, "id", (long) i);
+            users.add(user);
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            User user = users.get(i % users.size());
+
+            executorService.submit(() -> {
+                try {
+                    boardGameService.wishBoardGame(user, savedGame.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        BoardGame findGame = boardGameQueryRepository.findById(1L).orElseThrow();
+
+        assertThat(findGame.getWishCount()).isEqualTo(threadCount);
+    }
+
+}

--- a/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameServiceTest.java
@@ -110,10 +110,6 @@ class BoardGameServiceTest {
     @Test
     @DisplayName("[조건을 만족하지 못하는 보드게임은 조회되지 않는다]")
     void findAllWithWrongCondition() {
-        BoardGameCategory warGame = BoardGameFixture.getBoardGameCategory(WAR);
-        BoardGameCategory familyGame = BoardGameFixture.getBoardGameCategory(FAMILY);
-        BoardGame boardGame = BoardGameFixture.getBoardGame(List.of(warGame, familyGame));
-
         BoardGameSearchCondition condition = new BoardGameSearchCondition(
             "어려움",
             List.of(),
@@ -143,21 +139,15 @@ class BoardGameServiceTest {
         BoardGame boardGame = BoardGameFixture.getBoardGame(
             List.of(BoardGameFixture.getBoardGameCategory(WAR))
         );
-        int prevWishCount = boardGame.getWishCount();
         ReflectionTestUtils.setField(boardGame, "id", 1L);
 
         Wish wish = BoardGameFixture.getWish(user.getId(), boardGame.getId());
 
-        given(boardGameQueryRepository.findById(1L)).willReturn(Optional.of(boardGame));
+        given(boardGameQueryRepository.findByIdWithLock(1L)).willReturn(Optional.of(boardGame));
         given(
             wishRepository.findByUserIdAndBoardGameId(user.getId(), boardGame.getId())).willReturn(
             Optional.empty());
         given(wishRepository.save(any(Wish.class))).willReturn(wish);
-
-        WishBoardGameResponse response = boardGameService.wishBoardGame(
-            user,
-            boardGame.getId()
-        );
 
         assertThat(boardGame.getWishCount()).isEqualTo(1);
     }
@@ -176,7 +166,7 @@ class BoardGameServiceTest {
 
         Wish wish = BoardGameFixture.getWish(user.getId(), boardGame.getId());
 
-        given(boardGameQueryRepository.findById(1L)).willReturn(Optional.of(boardGame));
+        given(boardGameQueryRepository.findByIdWithLock(1L)).willReturn(Optional.of(boardGame));
         given(
             wishRepository.findByUserIdAndBoardGameId(user.getId(), boardGame.getId())).willReturn(
             Optional.of(wish));
@@ -197,9 +187,7 @@ class BoardGameServiceTest {
         );
         ReflectionTestUtils.setField(boardGame, "id", 1L);
 
-        Wish wish = BoardGameFixture.getWish(user.getId(), boardGame.getId());
-
-        given(boardGameQueryRepository.findById(1L)).willReturn(Optional.empty());
+        given(boardGameQueryRepository.findByIdWithLock(1L)).willReturn(Optional.empty());
 
         ThrowingCallable when = () -> boardGameService.wishBoardGame(user, boardGame.getId());
         assertThatThrownBy(when)

--- a/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/boardgame/application/BoardGameServiceTest.java
@@ -149,6 +149,8 @@ class BoardGameServiceTest {
             Optional.empty());
         given(wishRepository.save(any(Wish.class))).willReturn(wish);
 
+        boardGameService.wishBoardGame(user, boardGame.getId());
+
         assertThat(boardGame.getWishCount()).isEqualTo(1);
     }
 


### PR DESCRIPTION
- closed #36 

### ⛏ 작업 상세 내용

- 찜 등록 시 동시성 이슈 제어
- DB 비관적락 적용
- 동시성 테스트(50명이 찜 등록 시 찜 수 50)

### ✅ 중점적으로 리뷰 할 부분

- 이번 Pr은 작업량이 매우 적어서.. 그냥 보시면 될 것 같습니다😃

### 참고사항
