### PR TITLE
feat : 방을 단일조회 할 수 있다.

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -7,6 +7,7 @@ import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -72,5 +74,16 @@ public class RoomController {
         RoomPageResponse<GetAllRoomResponse> rooms = roomService.findRoomBySearch(condition,
             pageable);
         return ResponseEntity.ok(rooms);
+    }
+
+    @Operation(summary = "방 상세정보 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/{roomId}")
+    public ResponseEntity<RoomInfoResponse> getRoomInfo(
+        @PathVariable("roomId") Long roomId,
+        @AuthenticationPrincipal User user
+    ) {
+        RoomInfoResponse roomInfo = roomService.findRoomInfo(user.getId(), roomId);
+        return ResponseEntity.ok(roomInfo);
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -20,10 +20,14 @@ import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
 import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +44,8 @@ import org.springframework.util.MultiValueMap;
 @DisplayName("[RoomController 테스트]")
 class RoomControllerTest extends ApiTestSupport {
 
+    @Autowired
+    private UserRepository userRepository;
     @Autowired
     private RoomRepository roomRepository;
     @Autowired
@@ -221,5 +227,68 @@ class RoomControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.size").value(100))
             .andExpect(jsonPath("$.hasNext").value(false))
             .andExpect(jsonPath("$.roomsInfos.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("[방장이 non-fix 방 상세정보를 조회한다]")
+    void getRoomInfoTest() throws Exception {
+        //given
+        Room room = RoomFixture.getRoom();
+        roomRepository.save(room);
+
+        Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
+        participantRepository.save(participant);
+
+        mockMvc.perform(get("/api/v1/rooms/" + room.getId())
+                .header(AUTHORIZATION, accessToken))
+            .andExpect(jsonPath("$.roomId").value(room.getId()))
+            .andExpect(jsonPath("$.title").value(room.getTitle()))
+            .andExpect(jsonPath("$.startTime").value(
+                room.getDaySlot().getDescription()
+                    + " " + room.getTimeSlot().getDescription()))
+            .andExpect(jsonPath("$.isFix").value("미확정"))
+            .andExpect(jsonPath("$.isLeader").value(true))
+            .andExpect(jsonPath("$.place").value(
+                room.getSubwayStation() + " " + room.getPlaceName()
+            ))
+            .andExpect(jsonPath("$.participantResponse[0].isLeader")
+                .value(true))
+            .andExpect(jsonPath("$.participantResponse[0].nickname")
+                .value("injuning"));
+    }
+
+    @Test
+    @DisplayName("[방장이 아닌 사람이 fix 방 상세정보를 조회한다]")
+    void getRoomInfoTest2() throws Exception {
+        //given
+        User anotherUser = UserFixture.getUserFixture2("providerId", "imageUrl");
+        userRepository.save(anotherUser);
+
+        Room room = RoomFixture.getRoom();
+        roomRepository.save(room);
+
+        Participant participant = Participant.of(anotherUser.getId(), room.getId(), true);
+        participantRepository.save(participant);
+
+        MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
+            LocalDateTime.of(2024, 02, 26, 20, 3, 59));
+        meetingInfoRepository.save(meetingInfo);
+        room.fixRoom(meetingInfo);
+        roomRepository.save(room);
+
+        mockMvc.perform(get("/api/v1/rooms/" + room.getId())
+                .header(AUTHORIZATION, accessToken))
+            .andExpect(jsonPath("$.roomId").value(room.getId()))
+            .andExpect(jsonPath("$.title").value(room.getTitle()))
+            .andExpect(jsonPath("$.startTime").value(
+                meetingInfo.getMeetingTime()
+                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))))
+            .andExpect(jsonPath("$.place").value(
+                meetingInfo.getStation()
+                    + " " + meetingInfo.getMeetingPlace()
+            ))
+            .andExpect(jsonPath("$.participantResponse.size()").value(1))
+            .andExpect(jsonPath("$.participantResponse[0].nickname")
+                .value("macbook"));
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -1,6 +1,9 @@
 package com.civilwar.boardsignal.room.application;
 
+import com.civilwar.boardsignal.common.exception.NotFoundException;
 import com.civilwar.boardsignal.image.domain.ImageRepository;
+import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
@@ -10,9 +13,13 @@ import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.ParticipantResponse;
+import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
+import com.civilwar.boardsignal.room.exception.RoomErrorCode;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -31,6 +38,12 @@ public class RoomService {
     private final ParticipantRepository participantRepository;
     private final ImageRepository imageRepository;
     private final Supplier<LocalDateTime> now;
+
+    private static String concat(String string1, String string2) {
+        return string1
+            + " "
+            + string2;
+    }
 
     @Transactional
     public CreateRoomResponse createRoom(User user, CreateRoomRequest request) {
@@ -91,6 +104,42 @@ public class RoomService {
     ) {
         Slice<Room> findRooms = roomRepository.findAll(roomSearchCondition, pageable);
         return RoomMapper.toRoomPageResponse(findRooms);
+    }
+
+    @Transactional(readOnly = true)
+    public RoomInfoResponse findRoomInfo(Long userId, Long roomId) {
+        //1. 모임 정보 & 모임 확정 정보 (MeetingInfo)
+        Room findRoom = roomRepository.findById(roomId)
+            .orElseThrow(() -> new NotFoundException(RoomErrorCode.NOT_FOUND_ROOM));
+
+        //1-1. 모임 시간 & 장소 정보 추출
+        String resultPlace = concat(findRoom.getSubwayStation(), findRoom.getPlaceName());
+        String resultTime = concat(findRoom.getDaySlot().getDescription(),
+            findRoom.getTimeSlot().getDescription());
+
+        //2. 모임 확정 여부 확인
+        //모임 확정이라면 -> 모임 확정 시간 장소 정보로 제공
+        if (findRoom.getStatus().equals(RoomStatus.FIX)) {
+            MeetingInfo meetingInfo = findRoom.getMeetingInfo();
+            resultTime = meetingInfo.getMeetingTime()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+            resultPlace = concat(meetingInfo.getStation(), meetingInfo.getMeetingPlace());
+        }
+
+        //3. 방 참가자 정보
+        List<ParticipantResponse> participants = participantRepository.findParticipantByRoomId(roomId)
+            .stream()
+            .map(RoomMapper::toParticipantResponse)
+            .toList();
+
+        //4. 현재 사용자의 방장 여부 확인
+        Boolean isLeader = participants.stream()
+            .filter(participant -> participant.userId().equals(userId))
+            .map(ParticipantResponse::isLeader)
+            .findAny()
+            .orElse(false);
+
+        return RoomMapper.toRoomInfoResponse(findRoom, resultTime, resultPlace, isLeader, participants);
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -28,6 +28,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.lang.NonNull;
 
 @Entity
@@ -93,6 +94,7 @@ public class Room extends BaseEntity {
     @JoinColumn(name = "ROOM_MEETING_INFO_ID", foreignKey = @ForeignKey(NO_CONSTRAINT))
     private MeetingInfo meetingInfo;
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private final List<RoomCategory> roomCategories = new ArrayList<>();
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
@@ -1,7 +1,9 @@
 package com.civilwar.boardsignal.room.domain.repository;
 
 import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import java.util.Collection;
+import java.util.List;
 
 public interface ParticipantRepository {
 
@@ -9,4 +11,5 @@ public interface ParticipantRepository {
 
     void saveAll(Collection<Participant> participants);
 
+    List<ParticipantJpaDto> findParticipantByRoomId(Long roomId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -7,6 +7,9 @@ import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
+import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
+import com.civilwar.boardsignal.room.dto.response.ParticipantResponse;
+import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import java.util.List;
 import lombok.AccessLevel;
@@ -79,6 +82,43 @@ public final class RoomMapper {
             dto.getContent(),
             dto.getSize(),
             dto.hasNext()
+        );
+    }
+
+    public static RoomInfoResponse toRoomInfoResponse(
+        Room room,
+        String time,
+        String place,
+        Boolean isLeader,
+        List<ParticipantResponse> participants
+    ) {
+        return new RoomInfoResponse(
+            room.getId(),
+            room.getTitle(),
+            room.getDescription(),
+            time,
+            place,
+            room.getMinAge(),
+            room.getMaxAge(),
+            room.getImageUrl(),
+            isLeader,
+            room.getStatus().getDescription(),
+            room.isAllowedOppositeGender(),
+            room.getRoomCategories().stream()
+                .map(roomCategory -> roomCategory.getCategory().getDescription())
+                .toList(),
+            participants,
+            room.getCreatedAt()
+        );
+    }
+
+    public static ParticipantResponse toParticipantResponse(ParticipantJpaDto participantJpaDto) {
+        return new ParticipantResponse(
+            participantJpaDto.userId(),
+            participantJpaDto.nickname(),
+            participantJpaDto.ageGroup().getDescription(),
+            participantJpaDto.isLeader(),
+            participantJpaDto.mannerScore()
         );
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ParticipantJpaDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ParticipantJpaDto.java
@@ -1,0 +1,13 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
+
+public record ParticipantJpaDto(
+    Long userId,
+    String nickname,
+    AgeGroup ageGroup,
+    Boolean isLeader,
+    double mannerScore
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ParticipantResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ParticipantResponse.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+public record ParticipantResponse(
+    Long userId,
+    String nickname,
+    String ageGroup,
+    Boolean isLeader,
+    double mannerScore
+) {
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomInfoResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomInfoResponse.java
@@ -1,0 +1,26 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RoomInfoResponse(
+    Long roomId,
+    String title,
+    String description,
+    String startTime,
+    String place,
+    int minAge,
+    int maxAge,
+    String imageUrl,
+    Boolean isLeader,
+    String isFix,
+    Boolean isAllowedAppositeGender,
+    List<String> categories,
+    List<ParticipantResponse> participantResponse,
+    @JsonFormat(pattern = "MM-dd'T'HH:mm:ss")
+    LocalDateTime createdAt
+
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
@@ -1,0 +1,17 @@
+package com.civilwar.boardsignal.room.exception;
+
+import com.civilwar.boardsignal.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoomErrorCode implements ErrorCode {
+
+    NOT_FOUND_ROOM("해당 모임을 찾을 수 없습니다", "R_001");
+
+
+    private final String message;
+    private final String code;
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
@@ -2,8 +2,11 @@ package com.civilwar.boardsignal.room.infrastructure.adaptor;
 
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
+import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import com.civilwar.boardsignal.room.infrastructure.repository.ParticipantJpaRepository;
+import com.civilwar.boardsignal.room.infrastructure.repository.ParticipantQueryJpaRepository;
 import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Repository;
 public class ParticipantRepositoryAdaptor implements ParticipantRepository {
 
     private final ParticipantJpaRepository participantJpaRepository;
+    private final ParticipantQueryJpaRepository participantQueryJpaRepository;
 
     @Override
     public Participant save(Participant participant) {
@@ -21,5 +25,10 @@ public class ParticipantRepositoryAdaptor implements ParticipantRepository {
     @Override
     public void saveAll(Collection<Participant> participants) {
         participantJpaRepository.saveAll(participants);
+    }
+
+    @Override
+    public List<ParticipantJpaDto> findParticipantByRoomId(Long roomId) {
+        return participantQueryJpaRepository.findParticipantByRoomId(roomId);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantQueryJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantQueryJpaRepository.java
@@ -1,0 +1,21 @@
+package com.civilwar.boardsignal.room.infrastructure.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ParticipantQueryJpaRepository extends JpaRepository<Participant, Long> {
+
+    @Query(
+        "select new com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto("
+            + "u.id, u.nickname, u.ageGroup, p.isLeader, u.mannerScore"
+            + ") "
+            + "from Participant as p "
+            + "join User as u "
+            + "on p.userId = u.id "
+            + "where p.roomId = :roomId")
+    List<ParticipantJpaDto> findParticipantByRoomId(@Param("roomId") Long roomId);
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -2,12 +2,17 @@ package com.civilwar.boardsignal.room.infrastructure.repository;
 
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface RoomJpaRepository extends JpaRepository<Room, Long> {
+
+    @EntityGraph(attributePaths = {"roomCategories", "meetingInfo"})
+    @Override
+    Optional<Room> findById(Long roomId);
 
     // 내가 참여한 모든 room 조회 쿼리
     @EntityGraph(attributePaths = {"roomCategories", "meetingInfo"})

--- a/core/src/test/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.civilwar.boardsignal.room.domain.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.civilwar.boardsignal.common.support.DataJpaTestSupport;
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ParticipantRepositoryTest extends DataJpaTestSupport {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Test
+    @DisplayName("[DB에서 Dto 프로젝션을 통해 참가자 정보를 가져온다]")
+    void findParticipantByRoomIdTest() {
+        //given
+        Long roomId = 1L;
+        User user1 = UserFixture.getUserFixture("providerId", "imageUrl");
+        User user2 = UserFixture.getUserFixture2("providerId", "imageUrl");
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Participant participant1 = Participant.of(user1.getId(), roomId, true);
+        Participant participant2 = Participant.of(user2.getId(), roomId, false);
+        participantRepository.save(participant1);
+        participantRepository.save(participant2);
+
+        //when
+        List<ParticipantJpaDto> participants = participantRepository.findParticipantByRoomId(
+            roomId);
+
+        //then
+        ParticipantJpaDto participantJpaDto1 = participants.get(0);
+        ParticipantJpaDto participantJpaDto2 = participants.get(1);
+        assertThat(participants).hasSize(2);
+        assertThat(participantJpaDto1.userId()).isEqualTo(user1.getId());
+        assertThat(participantJpaDto1.nickname()).isEqualTo(user1.getNickname());
+        assertThat(participantJpaDto1.ageGroup()).isEqualTo(user1.getAgeGroup());
+        assertThat(participantJpaDto1.isLeader()).isEqualTo(participant1.isLeader());
+
+        assertThat(participantJpaDto2.userId()).isEqualTo(user2.getId());
+        assertThat(participantJpaDto2.nickname()).isEqualTo(user2.getNickname());
+        assertThat(participantJpaDto2.ageGroup()).isEqualTo(user2.getAgeGroup());
+        assertThat(participantJpaDto2.isLeader()).isEqualTo(participant2.isLeader());
+    }
+}


### PR DESCRIPTION
- closed #18 

### ⛏ 작업 상세 내용

- 방 단일 조회 API

- 방 단일 조회 시 응답 요구사항
1. 방 정보
2. 모임 확정 정보
3. 참가자 정보
4. 현재 로그인한 유저 방장 여부

### ✅ 중점적으로 리뷰 할 부분

- RoomService 로직
- 테스트 케이스 놓친 부분?

### 참고사항
- RoomService 부분은 커밋 메시지로 흐름을 정리하였습니다..!!