### PR TITLE
feat : 좋아요 등록 및 취소 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -97,7 +97,7 @@ public class BoardGameController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "보드게임 공략 좋아요 API")
+    @Operation(summary = "보드게임 공략 좋아요 취소 API")
     @ApiResponse(useReturnTypeSchema = true)
     @DeleteMapping("/{tipId}")
     public ResponseEntity<LikeTipResponse> cancelLikeTip(

--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -10,6 +10,7 @@ import com.civilwar.boardsignal.boardgame.dto.response.AddTipResposne;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetBoardGameResponse;
+import com.civilwar.boardsignal.boardgame.dto.response.LikeTipResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.WishBoardGameResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -82,4 +84,29 @@ public class BoardGameController {
         GetBoardGameResponse response = boardGameService.getBoardGame(boardGameId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "보드게임 공략 좋아요 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/{tipId}")
+    public ResponseEntity<LikeTipResponse> likeTip(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        @PathVariable("tipId") Long tipId
+    ) {
+        LikeTipResponse response = boardGameService.likeTip(user, tipId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "보드게임 공략 좋아요 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @DeleteMapping("/{tipId}")
+    public ResponseEntity<LikeTipResponse> cancelLikeTip(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        @PathVariable("tipId") Long tipId
+    ) {
+        LikeTipResponse response = boardGameService.cancelLikeTip(user, tipId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -21,7 +21,6 @@ import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
 import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,6 +39,12 @@ import org.springframework.util.MultiValueMap;
 @DisplayName("[RoomController 테스트]")
 class RoomControllerTest extends ApiTestSupport {
 
+    private final String title = "달무티 할 사람";
+    private final String description = "20대만";
+    private final String station = "사당역";
+    private final DaySlot daySlot = DaySlot.WEEKDAY;
+    private final TimeSlot timeSlot = TimeSlot.AM;
+    private final List<Category> categories = List.of(Category.FAMILY, Category.PARTY);
     @Autowired
     private RoomRepository roomRepository;
     @Autowired
@@ -48,14 +53,6 @@ class RoomControllerTest extends ApiTestSupport {
     private MeetingInfoJpaRepository meetingInfoRepository;
     @MockBean
     private Supplier<LocalDateTime> nowTime;
-
-    private final String title = "달무티 할 사람";
-    private final String description = "20대만";
-    private final String station = "사당역";
-    private final DaySlot daySlot = DaySlot.WEEKDAY;
-    private final TimeSlot timeSlot = TimeSlot.AM;
-    private final List<Category> categories = List.of(Category.FAMILY, Category.PARTY);
-
 
     @Test
     @DisplayName("[사용자는 방을 생성할 수 있다.]")

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Like.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Like.java
@@ -1,0 +1,52 @@
+package com.civilwar.boardsignal.boardgame.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "LIKE_TABLE")
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "LIKE_ID")
+    private Long id;
+
+    @Column(name = "LIKE_TIP_ID")
+    private Long tipId;
+
+    @Column(name = "LIKE_USER_ID")
+    private Long userId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Like(
+        Long tipId,
+        Long userId
+    )
+    {
+        this.tipId = tipId;
+        this.userId = userId;
+    }
+
+    public static Like of(
+        Long tipId,
+        Long userId
+    )
+    {
+        return Like.builder()
+            .tipId(tipId)
+            .userId(userId)
+            .build();
+    }
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Like.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Like.java
@@ -32,8 +32,7 @@ public class Like {
     private Like(
         Long tipId,
         Long userId
-    )
-    {
+    ) {
         this.tipId = tipId;
         this.userId = userId;
     }
@@ -41,8 +40,7 @@ public class Like {
     public static Like of(
         Long tipId,
         Long userId
-    )
-    {
+    ) {
         return Like.builder()
             .tipId(tipId)
             .userId(userId)

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Like.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Like.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @NoArgsConstructor
@@ -30,8 +31,8 @@ public class Like {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Like(
-        Long tipId,
-        Long userId
+        @NonNull Long tipId,
+        @NonNull Long userId
     ) {
         this.tipId = tipId;
         this.userId = userId;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Tip.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/entity/Tip.java
@@ -33,6 +33,9 @@ public class Tip extends BaseEntity {
     @Column(name = "TIP_CONTENT")
     private String content;
 
+    @Column(name = "TIP_LIKE_COUNT")
+    private int likeCount;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Tip(
         @NonNull Long boardGameId,
@@ -42,6 +45,7 @@ public class Tip extends BaseEntity {
         this.boardGameId = boardGameId;
         this.userId = userId;
         this.content = content;
+        this.likeCount = 0;
     }
 
     public static Tip of(
@@ -54,5 +58,13 @@ public class Tip extends BaseEntity {
             .userId(userId)
             .content(content)
             .build();
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/LikeRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/LikeRepository.java
@@ -1,0 +1,18 @@
+package com.civilwar.boardsignal.boardgame.domain.repository;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Like;
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeRepository {
+
+    List<Like> findAll();
+
+    Optional<Like> findById(Long id);
+
+    List<Like> findAllByTipId(Long tipId);
+
+    Like save(Like like);
+
+    void deleteByTipIdAndUserId(Long tipId, Long userId);
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/TipRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/TipRepository.java
@@ -15,4 +15,8 @@ public interface TipRepository {
 
     List<Tip> findAllByBoardGameId(Long boardGameId);
 
+    Optional<Tip> findById(Long id);
+
+    Optional<Tip> findByIdWithLock(Long id);
+
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/LikeTipResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/LikeTipResponse.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.boardgame.dto.response;
+
+public record LikeTipResponse(
+    Long tipId,
+    int likeCount
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
@@ -12,7 +12,8 @@ public enum BoardGameErrorCode implements ErrorCode {
     NOT_FOUND_BOARD_GAME("존재하지 않는 보드게임입니다", "B_001"),
     NOT_FOUND_DIFFICULTY("존재하지 않는 난이도입니다.", "B_002"),
     AlREADY_TIP_ADDED("이미 등록한 공략이 있는 보드게임입니다.", "B_003"),
-    NOT_FOUND_TIP_USER("해당 공략을 등록한 회원이 존재하지 않습니다.", "B_004");
+    NOT_FOUND_TIP_USER("해당 공략을 등록한 회원이 존재하지 않습니다.", "B_004"),
+    NOT_FOUND_TIP("존재하지 않는 공략입니다.", "B_005");
 
     private final String message;
     private final String code;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/LikeRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/LikeRepositoryAdaptor.java
@@ -1,0 +1,41 @@
+package com.civilwar.boardsignal.boardgame.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Like;
+import com.civilwar.boardsignal.boardgame.domain.repository.LikeRepository;
+import com.civilwar.boardsignal.boardgame.infrastructure.repository.LikeJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryAdaptor implements LikeRepository {
+
+    private final LikeJpaRepository likeJpaRepository;
+
+    @Override
+    public List<Like> findAll() {
+        return likeJpaRepository.findAll();
+    }
+
+    @Override
+    public Optional<Like> findById(Long id) {
+        return likeJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Like> findAllByTipId(Long tipId) {
+        return likeJpaRepository.findAllByTipId(tipId);
+    }
+
+    @Override
+    public Like save(Like like) {
+        return likeJpaRepository.save(like);
+    }
+
+    @Override
+    public void deleteByTipIdAndUserId(Long tipId, Long userId) {
+        likeJpaRepository.deleteByTipIdAndUserId(tipId, userId);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/TipRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/TipRepositoryAdaptor.java
@@ -34,4 +34,14 @@ public class TipRepositoryAdaptor implements TipRepository {
     public List<Tip> findAllByBoardGameId(Long boardGameId) {
         return tipJpaRepository.findAllByBoardGameId(boardGameId);
     }
+
+    @Override
+    public Optional<Tip> findById(Long id) {
+        return tipJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Tip> findByIdWithLock(Long id) {
+        return tipJpaRepository.findByIdWithLock(id);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/LikeJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/LikeJpaRepository.java
@@ -1,0 +1,12 @@
+package com.civilwar.boardsignal.boardgame.infrastructure.repository;
+
+import com.civilwar.boardsignal.boardgame.domain.entity.Like;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeJpaRepository extends JpaRepository<Like, Long> {
+
+    List<Like> findAllByTipId(Long tipId);
+
+    void deleteByTipIdAndUserId(Long tipId, Long userId);
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/TipJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/TipJpaRepository.java
@@ -1,13 +1,21 @@
 package com.civilwar.boardsignal.boardgame.infrastructure.repository;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TipJpaRepository extends JpaRepository<Tip, Long> {
 
     Optional<Tip> findByUserId(Long userId);
 
     List<Tip> findAllByBoardGameId(Long boardGameId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from Tip t where t.id = :id")
+    Optional<Tip> findByIdWithLock(@Param("id") Long id);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -3,7 +3,7 @@ package com.civilwar.boardsignal.room.domain.entity;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
-import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.EnumType.STRING;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.common.base.BaseEntity;
@@ -36,65 +36,48 @@ import org.springframework.lang.NonNull;
 @Table(name = "ROOM_TABLE")
 public class Room extends BaseEntity {
 
+    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
+    private final List<RoomCategory> roomCategories = new ArrayList<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ROOM_ID")
     private Long id;
-
     @Column(name = "ROOM_TITLE")
     private String title;
-
     @Column(name = "ROOM_DESCRIPTION")
     private String description;
-
     @Column(name = "ROOM_MIN_PARTICIPANTS")
     private int minParticipants;
-
     @Column(name = "ROOM_MAX_PARTICIPANTS")
     private int maxParticipants;
-
     @Column(name = "ROOM_STATUS")
     @Enumerated(STRING)
     private RoomStatus status;
-
     @Column(name = "ROOM_PLACE_NAME")
     private String placeName;
-
     @Column(name = "ROOM_SUBWAY_LINE")
     private String subwayLine;
-
     @Column(name = "ROOM_SUBWAY_STATION")
     private String subwayStation;
-
     @Column(name = "ROOM_DAY_SLOT")
     @Enumerated(STRING)
     private DaySlot daySlot;
-
     @Column(name = "ROOM_TIME_SLOT")
     @Enumerated(STRING)
     private TimeSlot timeSlot;
-
     @Column(name = "ROOM_START_TIME")
     private String startTime;
-
     @Column(name = "ROOM_MIN_AGE")
     private int minAge;
-
     @Column(name = "ROOM_MAX_AGE")
     private int maxAge;
-
     @Column(name = "ROOM_IMAGE_URL")
     private String imageUrl;
-
     @Column(name = "ROOM_IS_ALLOWED_OPPOSITE_GENDER")
     private boolean isAllowedOppositeGender;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ROOM_MEETING_INFO_ID", foreignKey = @ForeignKey(NO_CONSTRAINT))
     private MeetingInfo meetingInfo;
-
-    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private final List<RoomCategory> roomCategories = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Room(

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -37,8 +37,6 @@ import org.springframework.lang.NonNull;
 @Table(name = "ROOM_TABLE")
 public class Room extends BaseEntity {
 
-    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private final List<RoomCategory> roomCategories = new ArrayList<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ROOM_ID")

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -1,8 +1,8 @@
 package com.civilwar.boardsignal.room.infrastructure.adaptor;
 
-import static com.civilwar.boardsignal.room.domain.entity.QRoom.*;
-import static com.civilwar.boardsignal.room.domain.entity.QRoomCategory.*;
-import static org.springframework.util.StringUtils.*;
+import static com.civilwar.boardsignal.room.domain.entity.QRoom.room;
+import static com.civilwar.boardsignal.room.domain.entity.QRoomCategory.roomCategory;
+import static org.springframework.util.StringUtils.hasText;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.room.domain.constants.DaySlot;

--- a/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
@@ -20,7 +20,7 @@ public final class UserMapper {
         User user,
         List<UserReviewResponse> reviews,
         int wishCount
-        ) {
+    ) {
         return new UserProfileResponse(
             user.getNickname(),
             user.getSignal(),

--- a/core/src/test/java/com/civilwar/boardsignal/common/support/DataJpaTestSupport.java
+++ b/core/src/test/java/com/civilwar/boardsignal/common/support/DataJpaTestSupport.java
@@ -2,8 +2,8 @@ package com.civilwar.boardsignal.common.support;
 
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
-import com.civilwar.boardsignal.common.config.TestAuditingConfig;
 import com.civilwar.boardsignal.common.config.QueryDslConfig;
+import com.civilwar.boardsignal.common.config.TestAuditingConfig;
 import com.civilwar.boardsignal.support.DatabaseCleaner;
 import com.civilwar.boardsignal.support.DatabaseCleanerExtension;
 import com.civilwar.boardsignal.support.TestContainerSupport;

--- a/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
@@ -26,6 +26,13 @@ import org.springframework.data.domain.Slice;
 
 class RoomJpaRepositoryTest extends DataJpaTestSupport {
 
+    private final String title = "달무티 할 사람";
+    private final String description = "20대만";
+    private final String station = "사당역";
+    private final DaySlot daySlot = DaySlot.WEEKDAY;
+    private final TimeSlot timeSlot = TimeSlot.AM;
+    private final List<Category> categories = List.of(Category.FAMILY, Category.PARTY);
+    private final Boolean isAllowedOppositeGender = true;
     @PersistenceUnit
     EntityManagerFactory emf;
     @Autowired
@@ -34,14 +41,6 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
     private ParticipantJpaRepository participantJpaRepository;
     @Autowired
     private MeetingInfoJpaRepository meetingInfoJpaRepository;
-
-    private final String title = "달무티 할 사람";
-    private final String description = "20대만";
-    private final String station = "사당역";
-    private final DaySlot daySlot = DaySlot.WEEKDAY;
-    private final TimeSlot timeSlot = TimeSlot.AM;
-    private final List<Category> categories = List.of(Category.FAMILY, Category.PARTY);
-    private final Boolean isAllowedOppositeGender = true;
 
     @Test
     @DisplayName("[유저는 자신이 참여한 모든 room을 조회하며, roomCategory와 meetingInfo를 fetch loading 한다.]")
@@ -266,7 +265,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
             TimeSlot.PM,
             TimeSlot.AM
         );
-        for (int i=0 ; i<day.size() ; i++) {
+        for (int i = 0; i < day.size(); i++) {
             Room room = RoomFixture.getAnotherRoom(
                 title,
                 description,

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
@@ -41,7 +41,7 @@ public class RoomFixture {
         TimeSlot time,
         List<Category> categories,
         Boolean isAllowedOppositeGender
-        ) {
+    ) {
         return Room.of(
             title,
             description,


### PR DESCRIPTION
- closed #41 

### ⛏ 작업 상세 내용

- 좋아요 등록 및 취소 로직 구현
- Like 엔티티 설계
- Tip 엔티티 likeCount필드 추가 및 likeCount 증감메소드 정의

### ✅ 중점적으로 리뷰 할 부분

- 로직 상 빠진게 있는 지...잘 봐주시면 감사하겠슴다.

### 참고사항

- **코드 포맷팅이 밀려서 파일 체인지가 많으니 커밋별로 리뷰 권장 드립니다!**
- API 총 2개입니다.(등록, 취소)
