### PR TITLE
edit : 프로필 조회 API 수정

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
@@ -48,24 +48,14 @@ public class UserApiController {
         return ResponseEntity.ok(userModifyResponse);
     }
 
-    @Operation(summary = "본인 프로필 조회 API")
-    @ApiResponse(useReturnTypeSchema = true)
-    @GetMapping("/my")
-    public ResponseEntity<UserProfileResponse> getUserProfile(
-        @Parameter(hidden = true) @AuthenticationPrincipal User user
-    ) {
-        UserProfileResponse userProfileResponse = userService.getUserProfileInfo(user.getId());
-
-        return ResponseEntity.ok(userProfileResponse);
-    }
-
-    @Operation(summary = "타인 프로필 조회 API")
+    @Operation(summary = "프로필 조회 API")
     @ApiResponse(useReturnTypeSchema = true)
     @GetMapping("/{userId}")
     public ResponseEntity<UserProfileResponse> getAnotherUserProfile(
-        @PathVariable("userId") Long id
+        @Parameter(hidden = true) @AuthenticationPrincipal User loginUser,
+        @PathVariable("userId") Long profileUserId
     ) {
-        UserProfileResponse userProfileResponse = userService.getUserProfileInfo(id);
+        UserProfileResponse userProfileResponse = userService.getUserProfileInfo(profileUserId, loginUser);
 
         return ResponseEntity.ok(userProfileResponse);
     }

--- a/core/src/main/java/com/civilwar/boardsignal/user/application/UserService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/application/UserService.java
@@ -48,18 +48,21 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserProfileResponse getUserProfileInfo(Long id) {
+    public UserProfileResponse getUserProfileInfo(Long profileUserId, User loginUser) {
         //유저 정보 조회
-        User findUser = userRepository.findById(id)
+        User profileUser = userRepository.findById(profileUserId)
             .orElseThrow(() -> new NotFoundException(UserErrorCode.NOT_FOUND_USER));
 
         //찜 갯수 조회
-        int wishCount = wishRepository.countWishByUserId(id);
+        int wishCount = wishRepository.countWishByUserId(profileUserId);
 
         //유저와 관련된 리뷰 정보 조회
-        List<UserReviewResponse> userReviews = userReviewFacade.getUserReview(id);
+        List<UserReviewResponse> userReviews = userReviewFacade.getUserReview(profileUserId);
 
-        return UserMapper.toUserProfileResponse(findUser, userReviews, wishCount);
+        //프로필 방문 유저가 해당 프로필 주인인지 확인
+        Boolean isProfileManager = profileUserId.equals(loginUser.getId());
+
+        return UserMapper.toUserProfileResponse(profileUser, userReviews, wishCount, isProfileManager);
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/dto/response/UserProfileResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/dto/response/UserProfileResponse.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.user.dto.response;
 import java.util.List;
 
 public record UserProfileResponse(
+    Long profileUserId,
     String nickname,
     int signal,
     List<String> preferCategories,
@@ -11,7 +12,8 @@ public record UserProfileResponse(
     String profileImageUrl,
     double mannerScore,
     List<UserReviewResponse> reviews,
-    int wishCount
+    int wishCount,
+    Boolean isProfileManager
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
@@ -19,9 +19,11 @@ public final class UserMapper {
     public static UserProfileResponse toUserProfileResponse(
         User user,
         List<UserReviewResponse> reviews,
-        int wishCount
+        int wishCount,
+        Boolean isProfileManager
     ) {
         return new UserProfileResponse(
+            user.getId(),
             user.getNickname(),
             user.getSignal(),
             user.getUserCategories().stream()
@@ -32,7 +34,8 @@ public final class UserMapper {
             user.getProfileImageUrl(),
             user.getMannerScore(),
             reviews,
-            wishCount
+            wishCount,
+            isProfileManager
         );
     }
 


### PR DESCRIPTION
- closed #49 

### ⛏ 작업 상세 내용
- 본인 프로필 조회 API와 타인 프로필 조회 API를 통합한다
- 프로필 User id와 프로필 주인 여부를 추가로 응답한다.

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
