### PR TITLE
feat : 공략 삭제 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -87,7 +87,7 @@ public class BoardGameController {
 
     @Operation(summary = "보드게임 공략 좋아요 API")
     @ApiResponse(useReturnTypeSchema = true)
-    @PostMapping("/{tipId}")
+    @PostMapping("/like/{tipId}")
     public ResponseEntity<LikeTipResponse> likeTip(
         @Parameter(hidden = true)
         @AuthenticationPrincipal User user,
@@ -99,7 +99,7 @@ public class BoardGameController {
 
     @Operation(summary = "보드게임 공략 좋아요 취소 API")
     @ApiResponse(useReturnTypeSchema = true)
-    @DeleteMapping("/{tipId}")
+    @DeleteMapping("/like/{tipId}")
     public ResponseEntity<LikeTipResponse> cancelLikeTip(
         @Parameter(hidden = true)
         @AuthenticationPrincipal User user,
@@ -107,6 +107,17 @@ public class BoardGameController {
     ) {
         LikeTipResponse response = boardGameService.cancelLikeTip(user, tipId);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "보드게임 공략 삭제 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @DeleteMapping("/{tipId}")
+    public void deleteTip(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        @PathVariable("tipId") Long tipId
+    ) {
+        boardGameService.deleteTip(user, tipId);
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
@@ -143,4 +143,9 @@ public class BoardGameService {
 
         return new LikeTipResponse(tipId, tip.getLikeCount());
     }
+
+    @Transactional
+    public void deleteTip(User user, Long tipId) {
+        tipRepository.deleteByTipIdAndUserId(tipId, user.getId());
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/TipRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/TipRepository.java
@@ -19,4 +19,5 @@ public interface TipRepository {
 
     Optional<Tip> findByIdWithLock(Long id);
 
+    void deleteByTipIdAndUserId(Long tipId, Long userId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/TipRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/TipRepositoryAdaptor.java
@@ -44,4 +44,10 @@ public class TipRepositoryAdaptor implements TipRepository {
     public Optional<Tip> findByIdWithLock(Long id) {
         return tipJpaRepository.findByIdWithLock(id);
     }
+
+
+    @Override
+    public void deleteByTipIdAndUserId(Long tipId, Long userId) {
+        tipJpaRepository.deleteByIdAndUserId(tipId, userId);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/TipJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/TipJpaRepository.java
@@ -18,4 +18,6 @@ public interface TipJpaRepository extends JpaRepository<Tip, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select t from Tip t where t.id = :id")
     Optional<Tip> findByIdWithLock(@Param("id") Long id);
+
+    void deleteByIdAndUserId(Long id, Long userId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -127,7 +127,8 @@ public class RoomService {
         }
 
         //3. 방 참가자 정보
-        List<ParticipantResponse> participants = participantRepository.findParticipantByRoomId(roomId)
+        List<ParticipantResponse> participants = participantRepository.findParticipantByRoomId(
+                roomId)
             .stream()
             .map(RoomMapper::toParticipantResponse)
             .toList();
@@ -139,7 +140,8 @@ public class RoomService {
             .findAny()
             .orElse(false);
 
-        return RoomMapper.toRoomInfoResponse(findRoom, resultTime, resultPlace, isLeader, participants);
+        return RoomMapper.toRoomInfoResponse(findRoom, resultTime, resultPlace, isLeader,
+            participants);
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -37,6 +37,9 @@ import org.springframework.lang.NonNull;
 @Table(name = "ROOM_TABLE")
 public class Room extends BaseEntity {
 
+    @BatchSize(size = 10)
+    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
+    private final List<RoomCategory> roomCategories = new ArrayList<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ROOM_ID")
@@ -77,11 +80,6 @@ public class Room extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ROOM_MEETING_INFO_ID", foreignKey = @ForeignKey(NO_CONSTRAINT))
     private MeetingInfo meetingInfo;
-
-
-    @BatchSize(size = 10)
-    @OneToMany(mappedBy = "room", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private final List<RoomCategory> roomCategories = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Room(

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ParticipantResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ParticipantResponse.java
@@ -7,4 +7,5 @@ public record ParticipantResponse(
     Boolean isLeader,
     double mannerScore
 ) {
+
 }

--- a/core/src/test/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.room.domain.repository;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.civilwar.boardsignal.common.support.DataJpaTestSupport;
 import com.civilwar.boardsignal.room.domain.entity.Participant;


### PR DESCRIPTION
- closed #50 

### ⛏ 작업 상세 내용

- 공략 삭제 구현
- tipId 받아서 tipId와 userId를 통해 자신의 공략 삭제

### ✅ 중점적으로 리뷰 할 부분

- soft delete아니라 그냥 삭제하는 간단한 로직으로 짰습니다.

### 참고사항
