### PR TITLE
edit : 방 필터링 조회 API

### DIFF
--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.room.presentation;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,6 +22,7 @@ import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
 import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
 import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import java.io.FileInputStream;
@@ -29,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.function.Supplier;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -105,7 +108,55 @@ class RoomControllerTest extends ApiTestSupport {
         Room room = roomRepository.findById(1L).orElseThrow();
 
         resultActions.andExpect(jsonPath("$.roomId").value(room.getId()));
+        assertThat(room.getAllowedGender()).isEqualTo(Gender.UNION);
+    }
 
+    @Test
+    @DisplayName("[방 생성 시 이성 허용이 불가능하면, 방장의 성별이 방의 저장된다.]")
+    void createRoom2() throws Exception {
+        ApiCreateRoomRequest request = new ApiCreateRoomRequest(
+            "무슨무슨 모임입니다!",
+            "재밌게 하려고 모집중",
+            1,
+            6,
+            "주말",
+            "오전",
+            "토요일 오후 3:30",
+            21,
+            25,
+            "7호선",
+            "이수역",
+            "레드버튼 사당점",
+            List.of("가족게임", "컬렉터블게임"),
+            false
+        );
+
+        String fileName = "testFile.png";
+        MockMultipartFile data = new MockMultipartFile(
+            "data",
+            null,
+            "application/json",
+            toJson(request).getBytes(StandardCharsets.UTF_8)
+        );
+        MockMultipartFile image = new MockMultipartFile(
+            "image",
+            fileName,
+            "image/png",
+            new FileInputStream("src/test/resources/" + fileName)
+        );
+
+        ResultActions resultActions = mockMvc.perform(
+                multipart(HttpMethod.POST, "/api/v1/rooms")
+                    .file(image)
+                    .file(data)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, accessToken))
+            .andExpect(status().isOk());
+
+        Room room = roomRepository.findById(1L).orElseThrow();
+
+        resultActions.andExpect(jsonPath("$.roomId").value(room.getId()));
+        assertThat(room.getAllowedGender()).isEqualTo(loginUser.getGender());
     }
 
     @Test
@@ -119,7 +170,7 @@ class RoomControllerTest extends ApiTestSupport {
         //방 생성
         for (int i = 0; i < 6; i++) {
             //방 생성
-            Room room = RoomFixture.getRoom();
+            Room room = RoomFixture.getRoom(Gender.UNION);
             roomRepository.save(room);
 
             //방 참가
@@ -155,7 +206,7 @@ class RoomControllerTest extends ApiTestSupport {
         //모임 확정 시간이 아직 지나지 않은 방 생성
         for (int i = 0; i < 5; i++) {
             //방 생성
-            Room room = RoomFixture.getRoom();
+            Room room = RoomFixture.getRoom(Gender.UNION);
             roomRepository.save(room);
 
             //방 참가
@@ -172,7 +223,7 @@ class RoomControllerTest extends ApiTestSupport {
         //non-fix 방 생성
         for (int i = 0; i < 5; i++) {
             //방 생성
-            Room room = RoomFixture.getRoom();
+            Room room = RoomFixture.getRoom(Gender.UNION);
             roomRepository.save(room);
 
             //방 참가
@@ -197,7 +248,7 @@ class RoomControllerTest extends ApiTestSupport {
     void getSearchRoom() throws Exception {
         //given
         for (int i = 0; i < 100; i++) {
-            Room room = RoomFixture.getRoom();
+            Room room = RoomFixture.getRoom(Gender.UNION);
             roomRepository.save(room);
         }
         Room anotherRoom = RoomFixture.getAnotherRoom(
@@ -207,7 +258,7 @@ class RoomControllerTest extends ApiTestSupport {
             daySlot,
             timeSlot,
             categories,
-            true
+            Gender.MALE
         );
         roomRepository.save(anotherRoom);
 
@@ -217,6 +268,7 @@ class RoomControllerTest extends ApiTestSupport {
         params.add("station", station);
         params.add("time", "평일_오전");
         params.add("category", "파티게임");
+        params.add("gender", "남성");
 
         mockMvc.perform(get("/api/v1/rooms/filter")
                 .header(AUTHORIZATION, accessToken)
@@ -227,10 +279,45 @@ class RoomControllerTest extends ApiTestSupport {
     }
 
     @Test
+    @DisplayName("[조건이 하나라도 다르면 필터링 대상에서 제외된다]")
+    void getSearchRoom2() throws Exception {
+        //given
+        for (int i = 0; i < 100; i++) {
+            Room room = RoomFixture.getRoom(Gender.UNION);
+            roomRepository.save(room);
+        }
+        Room anotherRoom = RoomFixture.getAnotherRoom(
+            title,
+            description,
+            station,
+            daySlot,
+            timeSlot,
+            categories,
+            Gender.UNION
+        );
+        roomRepository.save(anotherRoom);
+
+        //then
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("size", "100");
+        params.add("station", station);
+        params.add("time", "평일_오전");
+        params.add("category", "파티게임");
+        params.add("gender", "남성");
+
+        mockMvc.perform(get("/api/v1/rooms/filter")
+                .header(AUTHORIZATION, accessToken)
+                .params(params))
+            .andExpect(jsonPath("$.size").value(100))
+            .andExpect(jsonPath("$.hasNext").value(false))
+            .andExpect(jsonPath("$.roomsInfos.length()").value(0));
+    }
+
+    @Test
     @DisplayName("[방장이 non-fix 방 상세정보를 조회한다]")
     void getRoomInfoTest() throws Exception {
         //given
-        Room room = RoomFixture.getRoom();
+        Room room = RoomFixture.getRoom(Gender.UNION);
         roomRepository.save(room);
 
         Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
@@ -250,6 +337,7 @@ class RoomControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.place").value(
                 room.getSubwayStation() + " " + room.getPlaceName()
             ))
+            .andExpect(jsonPath("$.allowedGender").value(Gender.UNION.getDescription()))
             .andExpect(jsonPath("$.participantResponse[0].isLeader")
                 .value(true))
             .andExpect(jsonPath("$.participantResponse[0].nickname")
@@ -263,7 +351,7 @@ class RoomControllerTest extends ApiTestSupport {
         User anotherUser = UserFixture.getUserFixture2("providerId", "imageUrl");
         userRepository.save(anotherUser);
 
-        Room room = RoomFixture.getRoom();
+        Room room = RoomFixture.getRoom(Gender.MALE);
         roomRepository.save(room);
 
         Participant participant = Participant.of(anotherUser.getId(), room.getId(), true);
@@ -286,6 +374,9 @@ class RoomControllerTest extends ApiTestSupport {
                 meetingInfo.getStation()
                     + " " + meetingInfo.getMeetingPlace()
             ))
+            .andExpect(jsonPath("$.isFix").value("확정"))
+            .andExpect(jsonPath("$.isLeader").value(false))
+            .andExpect(jsonPath("$.allowedGender").value(Gender.MALE.getDescription()))
             .andExpect(jsonPath("$.participantResponse.size()").value(1))
             .andExpect(jsonPath("$.participantResponse[0].nickname")
                 .value("macbook"));

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -17,6 +17,7 @@ import com.civilwar.boardsignal.room.dto.response.ParticipantResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import com.civilwar.boardsignal.room.exception.RoomErrorCode;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -48,8 +49,13 @@ public class RoomService {
     @Transactional
     public CreateRoomResponse createRoom(User user, CreateRoomRequest request) {
         String roomImageUrl = imageRepository.save(request.image());
+        Gender allowedGender = user.getGender();
+        //이성의 입장을 허용한다면
+        if(request.isAllowedOppositeGender()) {
+            allowedGender = Gender.UNION;
+        }
 
-        Room room = RoomMapper.toRoom(roomImageUrl, request);
+        Room room = RoomMapper.toRoom(roomImageUrl, request, allowedGender);
         Room savedRoom = roomRepository.save(room);
 
         Participant participant = Participant.of(

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -10,6 +10,7 @@ import com.civilwar.boardsignal.common.base.BaseEntity;
 import com.civilwar.boardsignal.room.domain.constants.DaySlot;
 import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
 import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -75,8 +76,11 @@ public class Room extends BaseEntity {
     private int maxAge;
     @Column(name = "ROOM_IMAGE_URL")
     private String imageUrl;
-    @Column(name = "ROOM_IS_ALLOWED_OPPOSITE_GENDER")
-    private boolean isAllowedOppositeGender;
+    @Column(name = "ROOM_ALLOWED_GENDER")
+    @Enumerated(STRING)
+    private Gender allowedGender;
+    @Column(name = "ROOM_HEAD_COUNT")
+    private int headCount;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ROOM_MEETING_INFO_ID", foreignKey = @ForeignKey(NO_CONSTRAINT))
     private MeetingInfo meetingInfo;
@@ -96,7 +100,7 @@ public class Room extends BaseEntity {
         int minAge,
         int maxAge,
         @NonNull String imageUrl,
-        @NonNull boolean isAllowedOppositeGender,
+        @NonNull Gender allowedGender,
         @NonNull List<Category> roomCategories
     ) {
         this.title = title;
@@ -113,11 +117,12 @@ public class Room extends BaseEntity {
         this.minAge = minAge;
         this.maxAge = maxAge;
         this.imageUrl = imageUrl;
-        this.isAllowedOppositeGender = isAllowedOppositeGender;
+        this.allowedGender = allowedGender;
         roomCategories.forEach(category -> {
             RoomCategory roomCategory = RoomCategory.of(this, category);
             this.roomCategories.add(roomCategory);
         });
+        this.headCount = 0;
     }
 
     public static Room of(
@@ -134,7 +139,7 @@ public class Room extends BaseEntity {
         int minAge,
         int maxAge,
         String imageUrl,
-        boolean isAllowedOppositeGender,
+        Gender allowedGender,
         List<Category> roomCategories
     ) {
         return Room.builder()
@@ -151,7 +156,7 @@ public class Room extends BaseEntity {
             .minAge(minAge)
             .maxAge(maxAge)
             .imageUrl(imageUrl)
-            .isAllowedOppositeGender(isAllowedOppositeGender)
+            .allowedGender(allowedGender)
             .roomCategories(roomCategories)
             .build();
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -11,6 +11,7 @@ import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import com.civilwar.boardsignal.room.dto.response.ParticipantResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -21,7 +22,8 @@ public final class RoomMapper {
 
     public static Room toRoom(
         String roomImageUrl,
-        CreateRoomRequest request
+        CreateRoomRequest request,
+        Gender allowedGender
     ) {
         DaySlot daySlot = DaySlot.of(request.day());
         TimeSlot timeSlot = TimeSlot.of(request.time());
@@ -43,7 +45,7 @@ public final class RoomMapper {
             request.minAge(),
             request.maxAge(),
             roomImageUrl,
-            request.isAllowedOppositeGender(),
+            allowedGender,
             categories
         );
     }
@@ -65,12 +67,13 @@ public final class RoomMapper {
             room.getStartTime(),
             room.getMinAge(),
             room.getMaxAge(),
-            room.isAllowedOppositeGender(),
+            room.getAllowedGender().getDescription(),
             room.getImageUrl(),
             room.getMinParticipants(),
             room.getMaxParticipants(),
             categories,
-            room.getCreatedAt()
+            room.getCreatedAt(),
+            room.getHeadCount()
         );
     }
 
@@ -105,7 +108,7 @@ public final class RoomMapper {
             room.getImageUrl(),
             isLeader,
             room.getStatus().getDescription(),
-            room.isAllowedOppositeGender(),
+            room.getAllowedGender().getDescription(),
             room.getRoomCategories().stream()
                 .map(roomCategory -> roomCategory.getCategory().getDescription())
                 .toList(),

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/request/RoomSearchCondition.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/request/RoomSearchCondition.java
@@ -7,7 +7,7 @@ public record RoomSearchCondition(
     List<String> station,
     List<String> time,
     List<String> category,
-    Boolean oppositeGender
+    String gender
 
 ) {
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetAllRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetAllRoomResponse.java
@@ -12,13 +12,14 @@ public record GetAllRoomResponse(
     String time,
     int minAge,
     int maxAge,
-    boolean isAllowedAppositeGender,
+    String allowedGender,
     String imageUrl,
     int minParticipants,
     int maxParticipants,
     List<String> categories,
     @JsonFormat(pattern = "MM-dd'T'HH:mm:ss")
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    int headCount
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomInfoResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomInfoResponse.java
@@ -17,7 +17,7 @@ public record RoomInfoResponse(
     String imageUrl,
     Boolean isLeader,
     String isFix,
-    Boolean isAllowedAppositeGender,
+    String allowedGender,
     List<String> categories,
     List<ParticipantResponse> participantResponse,
     @JsonFormat(pattern = "MM-dd'T'HH:mm:ss")

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -11,6 +11,7 @@ import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
 import com.civilwar.boardsignal.room.infrastructure.repository.RoomJpaRepository;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -30,12 +31,13 @@ public class RoomRepositoryAdaptor implements RoomRepository {
     private final RoomJpaRepository roomJpaRepository;
     private final JPAQueryFactory jpaQueryFactory;
 
-    private BooleanExpression equalAllowedOppositeGender(Boolean allowedOppositeGender) {
-        if (allowedOppositeGender == null) {
+    private BooleanExpression equalAllowedOppositeGender(String allowedGender) {
+        if (allowedGender == null) {
             return null;
         }
+        Gender genderType = Gender.toGender(allowedGender);
 
-        return room.isAllowedOppositeGender.eq(allowedOppositeGender);
+        return room.allowedGender.eq(genderType);
     }
 
     private BooleanExpression containsCategory(List<String> category) {
@@ -118,7 +120,7 @@ public class RoomRepositoryAdaptor implements RoomRepository {
                 containsStation(roomSearchCondition.station()),
                 containsAnyTime(roomSearchCondition.time()),
                 containsCategory(roomSearchCondition.category()),
-                equalAllowedOppositeGender(roomSearchCondition.oppositeGender())
+                equalAllowedOppositeGender(roomSearchCondition.gender())
             )
             .groupBy(room)
             .orderBy(room.createdAt.desc())

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/Gender.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/Gender.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 public enum Gender {
 
     MALE("male", "M", "남성"),
-    FEMALE("female", "F", "여성");
+    FEMALE("female", "F", "여성"),
+    UNION(null, null, "혼성");
 
     private final String kakaoType;
     private final String naverType;
@@ -31,5 +32,16 @@ public enum Gender {
         } else {
             return input.equalsIgnoreCase(this.naverType);
         }
+    }
+
+    public static Gender toGender(String input) {
+        return Arrays.stream(values())
+            .filter(gender -> gender.isEqual(input))
+            .findAny()
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_GENDER));
+    }
+
+    private boolean isEqual(String input) {
+        return input.equalsIgnoreCase(this.description);
     }
 }

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -21,6 +21,7 @@ import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import com.civilwar.boardsignal.user.UserFixture;
 import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -73,7 +74,7 @@ class RoomServiceTest {
         MockMultipartFile imageFixture = MultipartFileFixture.getMultipartFile();
 
         User user = UserFixture.getUserFixture("providerID", "imageUrl");
-        Room room = RoomFixture.getRoom();
+        Room room = RoomFixture.getRoom(user.getGender());
         Participant participant = RoomFixture.getParticipant();
 
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -105,7 +106,7 @@ class RoomServiceTest {
         //fix이면서 시간이 지난 방 -> 30개
         List<Room> testResult = new ArrayList<>();
         for (int i = 0; i < 30; i++) {
-            Room room = RoomFixture.getRoomWithMeetingInfo(before);
+            Room room = RoomFixture.getRoomWithMeetingInfo(before, Gender.UNION);
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
@@ -136,7 +137,7 @@ class RoomServiceTest {
         //fix이면서 아직 시간이 지나지 않은 방 -> 30개
         List<Room> testResult = new ArrayList<>();
         for (int i = 0; i < 30; i++) {
-            Room room = RoomFixture.getRoomWithMeetingInfo(after);
+            Room room = RoomFixture.getRoomWithMeetingInfo(after, Gender.UNION);
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
@@ -167,7 +168,7 @@ class RoomServiceTest {
         //fix이면서 시간이 지난 방 -> 30개
         List<Room> testResult = new ArrayList<>();
         for (int i = 0; i < 30; i++) {
-            Room room = RoomFixture.getRoomWithMeetingInfo(before);
+            Room room = RoomFixture.getRoomWithMeetingInfo(before, Gender.UNION);
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
@@ -198,7 +199,7 @@ class RoomServiceTest {
         //fix이면서 시간이 지난 방 -> 30개
         List<Room> testResult = new ArrayList<>();
         for (int i = 0; i < 30; i++) {
-            Room room = RoomFixture.getRoomWithMeetingInfo(before);
+            Room room = RoomFixture.getRoomWithMeetingInfo(before, Gender.UNION);
             ReflectionTestUtils.setField(room, "id", Long.parseLong(String.valueOf(i)));
             testResult.add(room);
         }
@@ -218,7 +219,7 @@ class RoomServiceTest {
     void findRoomInfoTest() throws IOException {
         //given
         Long loginUserId = 1L;
-        Room findRoom = RoomFixture.getRoom();
+        Room findRoom = RoomFixture.getRoom(Gender.UNION);
         ReflectionTestUtils.setField(findRoom, "id", 1L);
         List<ParticipantJpaDto> participantJpaDtos = List.of(new ParticipantJpaDto(
             1L, "김강훈", AgeGroup.TWENTY, true, 99
@@ -249,7 +250,7 @@ class RoomServiceTest {
     void findRoomInfoTest2() throws IOException {
         //given
         Long loginUserId = 2L;
-        Room findRoom = RoomFixture.getRoom();
+        Room findRoom = RoomFixture.getRoom(Gender.UNION);
         ReflectionTestUtils.setField(findRoom, "id", 1L);
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
             LocalDateTime.of(2023, 2, 26, 20, 3, 59));

--- a/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
@@ -13,6 +13,7 @@ import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceUnit;
 import java.io.IOException;
@@ -32,7 +33,6 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
     private final DaySlot daySlot = DaySlot.WEEKDAY;
     private final TimeSlot timeSlot = TimeSlot.AM;
     private final List<Category> categories = List.of(Category.FAMILY, Category.PARTY);
-    private final Boolean isAllowedOppositeGender = true;
     @PersistenceUnit
     EntityManagerFactory emf;
     @Autowired
@@ -48,8 +48,8 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
         //given
         Long user1 = 1L;
         Long user2 = 2L;
-        Room room = RoomFixture.getRoom();
-        Room room2 = RoomFixture.getRoom();
+        Room room = RoomFixture.getRoom(Gender.UNION);
+        Room room2 = RoomFixture.getRoom(Gender.UNION);
         roomRepository.save(room);
         roomRepository.save(room2);
 
@@ -100,7 +100,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
 
         for (int i = 0; i < 30; i++) {
             //방 생성
-            Room room = RoomFixture.getRoom();
+            Room room = RoomFixture.getRoom(Gender.UNION);
             roomRepository.save(room);
             Participant participant = Participant.of(user1, room.getId(), true);
             participantJpaRepository.save(participant);
@@ -137,7 +137,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
                 daySlot,
                 timeSlot,
                 categories,
-                isAllowedOppositeGender
+                Gender.UNION
             );
             roomRepository.save(room);
         }
@@ -180,8 +180,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
     @DisplayName("[동성만 입장 허용하는 방을 검색한다]")
     void findAllTest2() {
         //given
-        for (int i = 0; i < 100; i++) {
-            boolean allowedGender = i % 2 != 0;
+        for (int i = 0; i < 50; i++) {
             Room room = RoomFixture.getAnotherRoom(
                 title,
                 description,
@@ -189,7 +188,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
                 daySlot,
                 timeSlot,
                 categories,
-                allowedGender
+                Gender.UNION
             );
             roomRepository.save(room);
         }
@@ -200,7 +199,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
             null,
             null,
             null,
-            false
+            Gender.UNION.getDescription()
         );
         PageRequest pageRequest1 = PageRequest.of(0, 50);
 
@@ -226,7 +225,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
                 daySlot,
                 timeSlot,
                 categories,
-                isAllowedOppositeGender
+                Gender.UNION
             );
             roomRepository.save(room);
         }
@@ -273,7 +272,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
                 day.get(i),
                 time.get(i),
                 categories,
-                isAllowedOppositeGender
+                Gender.UNION
             );
             roomRepository.save(room);
         }
@@ -322,7 +321,7 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
                 daySlot,
                 timeSlot,
                 categoryList,
-                isAllowedOppositeGender
+                Gender.UNION
             );
             roomRepository.save(room);
         }

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
@@ -9,6 +9,7 @@ import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.mapper.RoomMapper;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,17 +21,17 @@ import org.springframework.web.multipart.MultipartFile;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RoomFixture {
 
-    public static Room getRoomWithMeetingInfo(LocalDateTime meetingTime) throws IOException {
+    public static Room getRoomWithMeetingInfo(LocalDateTime meetingTime, Gender gender) throws IOException {
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(meetingTime);
-        Room room = getRoom();
+        Room room = getRoom(gender);
         room.fixRoom(meetingInfo);
 
         return room;
     }
 
-    public static Room getRoom() throws IOException {
+    public static Room getRoom(Gender allowedGender) throws IOException {
         MockMultipartFile image = MultipartFileFixture.getMultipartFile();
-        return RoomMapper.toRoom("imageUrl", getCreateRoomRequest(image));
+        return RoomMapper.toRoom("imageUrl", getCreateRoomRequest(image), allowedGender);
     }
 
     public static Room getAnotherRoom(
@@ -40,7 +41,7 @@ public class RoomFixture {
         DaySlot day,
         TimeSlot time,
         List<Category> categories,
-        Boolean isAllowedOppositeGender
+        Gender allowedGender
     ) {
         return Room.of(
             title,
@@ -56,7 +57,7 @@ public class RoomFixture {
             20,
             29,
             "imageUrl",
-            isAllowedOppositeGender,
+            allowedGender,
             categories
         );
     }


### PR DESCRIPTION
- closed #48 

### ⛏ 작업 상세 내용
1. Room Entity 수정

2. 방 생성 시 -> 
- 이성 허용 여부 true -> 혼성 입장 가능
- 이성 허용 여부 false -> 남성 또는 여성만 입장 가능

3. 방 상세정보 조회, 필터링 조회 -> 응답 필드 변경

4. 테스트 보완

### ✅ 중점적으로 리뷰 할 부분

- 필드랑 로직이 일부 수정됨에 따라 통합 테스트 케이스 몇 개 추가했는데 혹시 놓친 게 있는지 봐주시면 감사하겠습니다!

### 참고사항
