### PR TITLE
feat : 클라이언트는 현재 로그인한 유저의 정보를확인할 수 있다

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/dto/response/LoginUserInfoResponse.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/dto/response/LoginUserInfoResponse.java
@@ -1,0 +1,12 @@
+package com.civilwar.boardsignal.auth.dto.response;
+
+public record LoginUserInfoResponse(
+    Long id,
+    String email,
+    String nickname,
+    String ageGroup,
+    String gender,
+    Boolean isJoined
+) {
+
+}

--- a/api/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthApiMapper.java
@@ -4,12 +4,13 @@ import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.auth.dto.OAuthUserInfo;
 import com.civilwar.boardsignal.auth.dto.request.UserLoginRequest;
 import com.civilwar.boardsignal.auth.dto.response.ApiUserLoginResponse;
+import com.civilwar.boardsignal.auth.dto.response.LoginUserInfoResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLoginResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class AuthApiMapper {
+public final class AuthApiMapper {
 
     public static UserLoginRequest toUserLoginRequest(OAuthUserInfo oAuthUserInfo) {
         return new UserLoginRequest(
@@ -30,5 +31,22 @@ public class AuthApiMapper {
         return new ApiUserLoginResponse(userLoginResponse.isJoined(), token.accessToken());
     }
 
+    public static LoginUserInfoResponse toLoginUserInfoResponse(
+        Long id,
+        String email,
+        String nickname,
+        String ageGroup,
+        String gender,
+        Boolean isJoined
+    ) {
+        return new LoginUserInfoResponse(
+            id,
+            email,
+            nickname,
+            ageGroup,
+            gender,
+            isJoined
+        );
+    }
 
 }

--- a/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
@@ -2,7 +2,10 @@ package com.civilwar.boardsignal.auth.presentation;
 
 import com.civilwar.boardsignal.auth.application.AuthService;
 import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
+import com.civilwar.boardsignal.auth.dto.response.LoginUserInfoResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLogoutResponse;
+import com.civilwar.boardsignal.auth.mapper.AuthApiMapper;
+import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,6 +71,25 @@ public class AuthApiController {
         response.addCookie(cookie);
         //로그아웃 성공 시 true 반환
         return ResponseEntity.ok(authService.logout(refreshTokenId));
+    }
+
+    @Operation(summary = "현재 로그인 한 사용자 정보 확인 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping
+    public ResponseEntity<LoginUserInfoResponse> getLoginUserInfo(
+        @AuthenticationPrincipal User loginUser) {
+
+        LoginUserInfoResponse loginUserInfoResponse = AuthApiMapper.toLoginUserInfoResponse(
+            loginUser.getId(),
+            loginUser.getEmail(),
+            loginUser.getNickname(),
+            loginUser.getAgeGroup().getDescription(),
+            loginUser.getGender().getDescription(),
+            loginUser.getIsJoined()
+        );
+
+        return ResponseEntity.ok(loginUserInfoResponse);
+
     }
 
 }

--- a/api/src/main/java/com/civilwar/boardsignal/review/presentation/ReviewController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/review/presentation/ReviewController.java
@@ -5,6 +5,9 @@ import com.civilwar.boardsignal.review.dto.ApiReviewSaveRequest;
 import com.civilwar.boardsignal.review.dto.request.ReviewSaveRequest;
 import com.civilwar.boardsignal.review.dto.response.ReviewSaveResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +25,12 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @Operation(summary = "리뷰 등록 API")
+    @ApiResponse(useReturnTypeSchema = true)
     @PostMapping("/{roomId}")
     public ResponseEntity<ReviewSaveResponse> postReviews(
         @RequestBody ApiReviewSaveRequest apiReviewSaveRequest,
-        @AuthenticationPrincipal User user,
+        @Parameter(hidden = true) @AuthenticationPrincipal User user,
         @PathVariable("roomId") Long roomId
     ) {
         List<ReviewSaveRequest> reviews = apiReviewSaveRequest.reviews();

--- a/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
@@ -82,4 +82,18 @@ class AuthApiControllerTest extends ApiTestSupport {
             )
             .andExpect(jsonPath("$.logoutResult").value(false));
     }
+
+    @Test
+    @DisplayName("[AccessToken의 사용자 정보를 반환한다.]")
+    void getLoginUserInfoTest() throws Exception {
+        //then
+        mockMvc.perform(get("/api/v1/auth")
+            .header(AUTHORIZATION, accessToken))
+            .andExpect(jsonPath("$.id").value(loginUser.getId()))
+            .andExpect(jsonPath("$.email").value(loginUser.getEmail()))
+            .andExpect(jsonPath("$.nickname").value(loginUser.getNickname()))
+            .andExpect(jsonPath("$.ageGroup").value(loginUser.getAgeGroup().getDescription()))
+            .andExpect(jsonPath("$.gender").value(loginUser.getGender().getDescription()))
+            .andExpect(jsonPath("$.isJoined").value(loginUser.getIsJoined()));
+    }
 }


### PR DESCRIPTION
- closed #52 

### ⛏ 작업 상세 내용
- AccessToken의 담긴 유저의 정보들을 단순 반환해주는 API 입니다.
- SecurityFilter에서 얻은 user의 정보를 컨트롤러에서 매핑해서 반환합니다

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
- 프론트에서 필요하다하여 구현합니다!
- 가볍게 보시면 될 것 같습니다ㅎㅎ