### PR TITLE
edit : 방 상세정보는 인증되지 않은 사용자들도 접근할 수 있다

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/config/SecurityConfig.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/config/SecurityConfig.java
@@ -50,10 +50,7 @@ public class SecurityConfig {
                 }
             ))
             .authorizeHttpRequests(registry -> registry
-                .requestMatchers("/api/v1/board-games").permitAll()
-                .requestMatchers("/api/v1/board-games/{boardGameId}").permitAll()
-                .requestMatchers("/api/v1/users").permitAll()
-                .requestMatchers("/api/**").authenticated()
+                .requestMatchers("/api/**").permitAll()
                 .anyRequest().permitAll()
             )
             .exceptionHandling(configurer -> configurer

--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -83,7 +83,7 @@ public class RoomController {
         @PathVariable("roomId") Long roomId,
         @AuthenticationPrincipal User user
     ) {
-        RoomInfoResponse roomInfo = roomService.findRoomInfo(user.getId(), roomId);
+        RoomInfoResponse roomInfo = roomService.findRoomInfo(user, roomId);
         return ResponseEntity.ok(roomInfo);
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -381,4 +381,41 @@ class RoomControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.participantResponse[0].nickname")
                 .value("macbook"));
     }
+
+    @Test
+    @DisplayName("[비로그인 유저가 fix 방 상세정보를 조회한다]")
+    void getRoomInfoTest3() throws Exception {
+        //given
+        User anotherUser = UserFixture.getUserFixture2("providerId", "imageUrl");
+        userRepository.save(anotherUser);
+
+        Room room = RoomFixture.getRoom(Gender.MALE);
+        roomRepository.save(room);
+
+        Participant participant = Participant.of(anotherUser.getId(), room.getId(), true);
+        participantRepository.save(participant);
+
+        MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
+            LocalDateTime.of(2024, 02, 26, 20, 3, 59));
+        meetingInfoRepository.save(meetingInfo);
+        room.fixRoom(meetingInfo);
+        roomRepository.save(room);
+
+        mockMvc.perform(get("/api/v1/rooms/" + room.getId()))
+            .andExpect(jsonPath("$.roomId").value(room.getId()))
+            .andExpect(jsonPath("$.title").value(room.getTitle()))
+            .andExpect(jsonPath("$.startTime").value(
+                meetingInfo.getMeetingTime()
+                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))))
+            .andExpect(jsonPath("$.place").value(
+                meetingInfo.getStation()
+                    + " " + meetingInfo.getMeetingPlace()
+            ))
+            .andExpect(jsonPath("$.isFix").value("확정"))
+            .andExpect(jsonPath("$.isLeader").value(false))
+            .andExpect(jsonPath("$.allowedGender").value(Gender.MALE.getDescription()))
+            .andExpect(jsonPath("$.participantResponse.size()").value(1))
+            .andExpect(jsonPath("$.participantResponse[0].nickname")
+                .value("macbook"));
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -113,7 +113,7 @@ public class RoomService {
     }
 
     @Transactional(readOnly = true)
-    public RoomInfoResponse findRoomInfo(Long userId, Long roomId) {
+    public RoomInfoResponse findRoomInfo(User user, Long roomId) {
         //1. 모임 정보 & 모임 확정 정보 (MeetingInfo)
         Room findRoom = roomRepository.findById(roomId)
             .orElseThrow(() -> new NotFoundException(RoomErrorCode.NOT_FOUND_ROOM));
@@ -139,12 +139,20 @@ public class RoomService {
             .map(RoomMapper::toParticipantResponse)
             .toList();
 
-        //4. 현재 사용자의 방장 여부 확인
-        Boolean isLeader = participants.stream()
-            .filter(participant -> participant.userId().equals(userId))
-            .map(ParticipantResponse::isLeader)
-            .findAny()
-            .orElse(false);
+        //4. 로그인 한 사용자인지 확인
+
+        //현재 로그인 상태가 아니라면 -> leaderX
+        Boolean isLeader = false;
+
+        //현재 로그인 상태라면 -> leader 확인
+        if (user != null){
+            //4. 현재 사용자의 방장 여부 확인
+            isLeader = participants.stream()
+                .filter(participant -> participant.userId().equals(user.getId()))
+                .map(ParticipantResponse::isLeader)
+                .findAny()
+                .orElse(false);
+        }
 
         return RoomMapper.toRoomInfoResponse(findRoom, resultTime, resultPlace, isLeader,
             participants);

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -218,6 +218,8 @@ class RoomServiceTest {
     @DisplayName("[non-fix 방을 방장이 조회하면, 방장 여부와 & 생성 시 작성한 방 정보가 조회된다]")
     void findRoomInfoTest() throws IOException {
         //given
+        User user = UserFixture.getUserFixture("providerId", "imageUrl");
+        ReflectionTestUtils.setField(user, "id", 1L);
         Long loginUserId = 1L;
         Room findRoom = RoomFixture.getRoom(Gender.UNION);
         ReflectionTestUtils.setField(findRoom, "id", 1L);
@@ -233,7 +235,7 @@ class RoomServiceTest {
             .willReturn(participantJpaDtos);
 
         //when
-        RoomInfoResponse roomInfo = roomService.findRoomInfo(loginUserId, findRoom.getId());
+        RoomInfoResponse roomInfo = roomService.findRoomInfo(user, findRoom.getId());
 
         //then
         assertThat(roomInfo.roomId()).isEqualTo(findRoom.getId());
@@ -249,7 +251,8 @@ class RoomServiceTest {
     @DisplayName("[fix 방을 방장이 아닌 사람이 조회하면, 방장 여부와 & 모임 확정 정보가 조회된다]")
     void findRoomInfoTest2() throws IOException {
         //given
-        Long loginUserId = 2L;
+        User user = UserFixture.getUserFixture("providerId", "imageUrl");
+        ReflectionTestUtils.setField(user, "id", 2L);
         Room findRoom = RoomFixture.getRoom(Gender.UNION);
         ReflectionTestUtils.setField(findRoom, "id", 1L);
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
@@ -268,7 +271,7 @@ class RoomServiceTest {
             .willReturn(participantJpaDtos);
 
         //when
-        RoomInfoResponse roomInfo = roomService.findRoomInfo(loginUserId, findRoom.getId());
+        RoomInfoResponse roomInfo = roomService.findRoomInfo(user, findRoom.getId());
 
         //then
         assertThat(roomInfo.roomId()).isEqualTo(findRoom.getId());


### PR DESCRIPTION
- closed #60 

### ⛏ 작업 상세 내용

- 방 상세정보 조회 시 방장을 구별해야 합니다
1. AccessToken 존재 시 -> 방장인지 아닌지 구별하여 응답
2. AccessToken 존재하지 않을 시 -> 무조건 방장이 아님 (기능 추가된 부분)

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
- SecurityConfig에서 접근을 허용하여도 @AuthenticationPrincipal이 동작하는 것을 확인하여, 일단 모든 api 열어두었습니다!
- #59 pr 시 인증 필요/불필요 api 구분하겠습니다!
- pr 폭탄 죄송함다...ㅠ