### PR TITLE
feat : 찜 취소 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -8,6 +8,7 @@ import com.civilwar.boardsignal.boardgame.dto.request.ApiAddTipRequest;
 import com.civilwar.boardsignal.boardgame.dto.request.BoardGameSearchCondition;
 import com.civilwar.boardsignal.boardgame.dto.response.AddTipResposne;
 import com.civilwar.boardsignal.boardgame.dto.response.BoardGamePageResponse;
+import com.civilwar.boardsignal.boardgame.dto.response.CancelWishResposne;
 import com.civilwar.boardsignal.boardgame.dto.response.GetAllBoardGamesResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.GetBoardGameResponse;
 import com.civilwar.boardsignal.boardgame.dto.response.LikeTipResponse;
@@ -58,6 +59,18 @@ public class BoardGameController {
         @PathVariable("boardGameId") Long boardGameId
     ) {
         WishBoardGameResponse response = boardGameService.wishBoardGame(user, boardGameId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "보드게임 찜 취소 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @DeleteMapping("/wish/{boardGameId}")
+    public ResponseEntity<CancelWishResposne> cancelWish(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        @PathVariable("boardGameId") Long boardGameId
+    ) {
+        CancelWishResposne response = boardGameService.cancelWish(user, boardGameId);
         return ResponseEntity.ok(response);
     }
 

--- a/api/src/main/java/com/civilwar/boardsignal/common/config/CorsConfig.java
+++ b/api/src/main/java/com/civilwar/boardsignal/common/config/CorsConfig.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.common.config;
 
-import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.boardgame.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,8 +12,10 @@ import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGameCategory;
 import com.civilwar.boardsignal.boardgame.domain.entity.Tip;
+import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import com.civilwar.boardsignal.boardgame.domain.repository.BoardGameRepository;
 import com.civilwar.boardsignal.boardgame.domain.repository.TipRepository;
+import com.civilwar.boardsignal.boardgame.domain.repository.WishRepository;
 import com.civilwar.boardsignal.boardgame.dto.request.ApiAddTipRequest;
 import com.civilwar.boardsignal.common.support.ApiTestSupport;
 import com.civilwar.boardsignal.fixture.BoardGameFixture;
@@ -41,6 +44,9 @@ class BoardGameControllerTest extends ApiTestSupport {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private WishRepository wishRepository;
 
     private BoardGame boardGame1;
 
@@ -97,7 +103,7 @@ class BoardGameControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @DisplayName("[특정 보드게임을 찜 등록을 하거나 취소할 수 있다.]")
+    @DisplayName("[특정 보드게임을 찜 등록 할 수 있다.]")
     void wishBoardGame() throws Exception {
         int prevWishCount = boardGame1.getWishCount();
         //찜 등록
@@ -106,12 +112,22 @@ class BoardGameControllerTest extends ApiTestSupport {
                 .header(AUTHORIZATION, accessToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.wishCount").value(prevWishCount + 1));
+    }
+
+    @Test
+    @DisplayName("[특정 보드게임에 대해 찜 취소를 할 수 있다.]")
+    void cancelWish() throws Exception {
+        Wish wish = Wish.of(loginUser.getId(), boardGame1.getId());
+        wishRepository.save(wish);
+
+        int prevWishCount = boardGame1.getWishCount();
+
         //찜 취소
-        mockMvc.perform(post("/api/v1/board-games/wish/{boardGameId}",
+        mockMvc.perform(delete("/api/v1/board-games/wish/{boardGameId}",
                 boardGame1.getId())
                 .header(AUTHORIZATION, accessToken))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.wishCount").value(prevWishCount));
+            .andExpect(jsonPath("$.wishCount").value(--prevWishCount));
     }
 
     @Test

--- a/api/src/test/java/com/civilwar/boardsignal/review/presentation/ReviewControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/review/presentation/ReviewControllerTest.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.review.presentation;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -63,11 +63,10 @@ class ReviewControllerTest extends ApiTestSupport {
 
         //then
         mockMvc.perform(post("/api/v1/reviews/" + roomId)
-            .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(apiReviewSaveRequest)))
             .andExpect(jsonPath("$.reviewIds.length()").value(3));
-
 
         Review review1 = reviewRepository.findById(1L).get();
         List<ReviewEvaluation> reviewEvaluations = review1.getReviewEvaluations();

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/CancelWishResposne.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/dto/response/CancelWishResposne.java
@@ -1,0 +1,5 @@
+package com.civilwar.boardsignal.boardgame.dto.response;
+
+public record CancelWishResposne(int wishCount) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
@@ -13,7 +13,9 @@ public enum BoardGameErrorCode implements ErrorCode {
     NOT_FOUND_DIFFICULTY("존재하지 않는 난이도입니다.", "B_002"),
     AlREADY_TIP_ADDED("이미 등록한 공략이 있는 보드게임입니다.", "B_003"),
     NOT_FOUND_TIP_USER("해당 공략을 등록한 회원이 존재하지 않습니다.", "B_004"),
-    NOT_FOUND_TIP("존재하지 않는 공략입니다.", "B_005");
+    NOT_FOUND_TIP("존재하지 않는 공략입니다.", "B_005"),
+    ALREADY_WISHED("이미 찜한 보드게임입니다.", "B_006"),
+    NOT_FOUND_WISH("찜한 적이 없는 보드게임입니다", "B_007");
 
     private final String message;
     private final String code;

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/constant/ReviewContent.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/constant/ReviewContent.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.review.domain.constant;
 
-import static com.civilwar.boardsignal.review.exception.ReviewErrorCode.*;
+import static com.civilwar.boardsignal.review.exception.ReviewErrorCode.NOT_FOUND_CONTENT;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import java.util.Arrays;

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -145,7 +145,7 @@ public class RoomService {
         Boolean isLeader = false;
 
         //현재 로그인 상태라면 -> leader 확인
-        if (user != null){
+        if (user != null) {
             //4. 현재 사용자의 방장 여부 확인
             isLeader = participants.stream()
                 .filter(participant -> participant.userId().equals(user.getId()))

--- a/core/src/test/java/com/civilwar/boardsignal/review/application/ReviewServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/review/application/ReviewServiceTest.java
@@ -70,6 +70,6 @@ class ReviewServiceTest {
 
         //then
         Assertions.assertThat(reviewSaveResponse.reviewIds()).hasSize(3);
-        verify(reviewRepository,times(3)).save(any(Review.class));
+        verify(reviewRepository, times(3)).save(any(Review.class));
     }
 }


### PR DESCRIPTION
- closed #66 
### ⛏ 작업 상세 내용

- 찜 취소 API 구현
- 기존에 찜 등록 로직에 등록, 취소 로직 들어가있던 것 분리
- 찜 등록 시 -> 이미 찜이 되어있다면 예외
- 찜 취소 시 -> 찜한 적이 없다면 예외

### ✅ 중점적으로 리뷰 할 부분

- 로직
- 테스트 코드

### 참고사항

- 보드게임 관련된거 말고 나머지는 코드 포맷팅이니 안 보셔도 됩니다!
