### PR TITLE
feat : 보드게임 찜 목록 조회 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/config/SecurityConfig.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(registry -> registry
                 //방
                 .requestMatchers(HttpMethod.GET, "/api/v1/rooms/my/end-games").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/v1/board-games/{userId}/wish")
+                .authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/v1/rooms/**").permitAll()
                 //보드게임
                 .requestMatchers(HttpMethod.GET, "/api/v1/board-games/**").permitAll()
@@ -51,6 +53,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/auth/reissue").permitAll()
                 .requestMatchers(HttpMethod.GET, "/oauth2/authorization/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/swagger-ui/index.html#/").permitAll()
                 .anyRequest().authenticated()
             )
             //인증 안 된 사용자 접근 시 예외 처리

--- a/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameController.java
@@ -135,4 +135,17 @@ public class BoardGameController {
         boardGameService.deleteTip(user, tipId);
     }
 
+    @Operation(summary = "보드게임 찜 목록 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/{userId}/wish")
+    public ResponseEntity<BoardGamePageResponse<GetAllBoardGamesResponse>> getAllWishBoardGames(
+        @PathVariable("userId") Long userId,
+        Pageable pageable
+    ) {
+        BoardGamePageResponse<GetAllBoardGamesResponse> response = boardGameService.getAllWishBoardGames(
+            userId, pageable
+        );
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/boardgame/presentation/BoardGameControllerTest.java
@@ -331,4 +331,41 @@ class BoardGameControllerTest extends ApiTestSupport {
                 jsonPath("$.myTip").doesNotExist()
             );
     }
+
+    @Test
+    @DisplayName("[찜한 보드게임 목록을 전체 조회할 수 있다.]")
+    void getAllWishBoardGames() throws Exception {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("size", "1");
+
+        Wish wish = Wish.of(loginUser.getId(), boardGame1.getId());
+        wishRepository.save(wish);
+
+        mockMvc.perform(get("/api/v1/board-games/{userId}/wish", loginUser.getId())
+                .params(params)
+                .header(AUTHORIZATION, accessToken))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.boardGamesInfos[0].name")
+                    .value(boardGame1.getTitle()),
+                jsonPath("$.boardGamesInfos[0].categories[0]")
+                    .value(boardGame2.getCategories().get(0).getCategory().getDescription()),
+                jsonPath("$.boardGamesInfos[0].difficulty")
+                    .value(boardGame1.getDifficulty().getDescription()),
+                jsonPath("$.boardGamesInfos[0].minParticipants")
+                    .value(boardGame1.getMinParticipants()),
+                jsonPath("$.boardGamesInfos[0].maxParticipants")
+                    .value(boardGame1.getMaxParticipants()),
+                jsonPath("$.boardGamesInfos[0].fromPlayTime")
+                    .value(boardGame1.getFromPlayTime()),
+                jsonPath("$.boardGamesInfos[0].toPlayTime")
+                    .value(boardGame1.getToPlayTime()),
+                jsonPath("$.boardGamesInfos[0].wishCount")
+                    .value(boardGame1.getWishCount()),
+                jsonPath("$.boardGamesInfos[0].imageUrl")
+                    .value(boardGame1.getMainImageUrl()),
+                jsonPath("$.size").value(1),
+                jsonPath("$.hasNext").value(false)
+            );
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/application/BoardGameService.java
@@ -204,4 +204,23 @@ public class BoardGameService {
     public void deleteTip(User user, Long tipId) {
         tipRepository.deleteByTipIdAndUserId(tipId, user.getId());
     }
+
+    @Transactional(readOnly = true)
+    public BoardGamePageResponse<GetAllBoardGamesResponse> getAllWishBoardGames(
+        Long userId,
+        Pageable pageable
+    ) {
+        //찜한 보드게임 아이디 전부 추출
+        List<Long> boardGameIds = wishRepository.findAllByUserId(userId).stream()
+            .map(Wish::getBoardGameId)
+            .toList();
+
+        //보드게임 아이디에 해당하는 보드게임 전체 조회
+        Slice<BoardGame> boardGames = boardGameQueryRepository.findAllInIds(boardGameIds, pageable);
+
+        Slice<GetAllBoardGamesResponse> findBoardGames = boardGames.map(
+            BoardGameMapper::toGetAllBoardGamesResponse); // 응답 dto 형식으로 변환
+
+        return BoardGameMapper.toBoardGamePageRepsonse(findBoardGames);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/constant/Category.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/constant/Category.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.boardgame.domain.constant;
 
-import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME_CATEGORY;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import java.util.Arrays;
@@ -27,7 +27,7 @@ public enum Category {
         return Arrays.stream(values())
             .filter(category -> category.isEqual(input))
             .findAny()
-            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME));
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME_CATEGORY));
     }
 
     private boolean isEqual(String input) {

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/constant/Difficulty.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/constant/Difficulty.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.boardgame.domain.constant;
 
-import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_DIFFICULTY;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ public enum Difficulty {
         return Arrays.stream(values())
             .filter(category -> category.isEqual(input))
             .findAny()
-            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME));
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_DIFFICULTY));
     }
 
     private boolean isEqual(String input) {

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/BoardGameQueryRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/BoardGameQueryRepository.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.boardgame.domain.repository;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import com.civilwar.boardsignal.boardgame.dto.request.BoardGameSearchCondition;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,5 +14,7 @@ public interface BoardGameQueryRepository {
     Slice<BoardGame> findAll(BoardGameSearchCondition condition, Pageable pageable);
 
     Optional<BoardGame> findByIdWithLock(Long id);
+
+    Slice<BoardGame> findAllInIds(List<Long> ids, Pageable pageable);
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/WishRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/domain/repository/WishRepository.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.boardgame.domain.repository;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface WishRepository {
@@ -15,4 +16,6 @@ public interface WishRepository {
     void deleteById(Long wishId);
 
     int countWishByUserId(Long userId);
+
+    List<Wish> findAllByUserId(Long userId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/exception/BoardGameErrorCode.java
@@ -15,7 +15,8 @@ public enum BoardGameErrorCode implements ErrorCode {
     NOT_FOUND_TIP_USER("해당 공략을 등록한 회원이 존재하지 않습니다.", "B_004"),
     NOT_FOUND_TIP("존재하지 않는 공략입니다.", "B_005"),
     ALREADY_WISHED("이미 찜한 보드게임입니다.", "B_006"),
-    NOT_FOUND_WISH("찜한 적이 없는 보드게임입니다", "B_007");
+    NOT_FOUND_WISH("찜한 적이 없는 보드게임입니다", "B_007"),
+    NOT_FOUND_BOARD_GAME_CATEGORY("존재하지 않는 보드게임 카테고리입니다.", "B_008");
 
     private final String message;
     private final String code;

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptor.java
@@ -101,4 +101,9 @@ public class BoardGameQueryRepositoryAdaptor implements BoardGameQueryRepository
     public Optional<BoardGame> findByIdWithLock(Long id) {
         return boardGameJpaRepository.findByIdWithLock(id);
     }
+
+    @Override
+    public Slice<BoardGame> findAllInIds(List<Long> ids, Pageable pageable) {
+        return boardGameJpaRepository.findAllInIds(ids, pageable);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/WishRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/WishRepositoryAdaptor.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
 import com.civilwar.boardsignal.boardgame.domain.repository.WishRepository;
 import com.civilwar.boardsignal.boardgame.infrastructure.repository.WishJpaRepository;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -37,5 +38,10 @@ public class WishRepositoryAdaptor implements WishRepository {
     @Override
     public int countWishByUserId(Long userId) {
         return wishJpaRepository.countWishByUserId(userId);
+    }
+
+    @Override
+    public List<Wish> findAllByUserId(Long userId) {
+        return wishJpaRepository.findAllByUserId(userId);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/BoardGameJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/BoardGameJpaRepository.java
@@ -2,7 +2,10 @@ package com.civilwar.boardsignal.boardgame.infrastructure.repository;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.BoardGame;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +16,7 @@ public interface BoardGameJpaRepository extends JpaRepository<BoardGame, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select b from BoardGame b where b.id = :id")
     Optional<BoardGame> findByIdWithLock(@Param("id") Long id);
+
+    @Query("select b from BoardGame b where b.id in :ids")
+    Slice<BoardGame> findAllInIds(@Param("ids") List<Long> ids, Pageable pageable);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/WishJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/boardgame/infrastructure/repository/WishJpaRepository.java
@@ -1,6 +1,7 @@
 package com.civilwar.boardsignal.boardgame.infrastructure.repository;
 
 import com.civilwar.boardsignal.boardgame.domain.entity.Wish;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface WishJpaRepository extends JpaRepository<Wish, Long> {
     Optional<Wish> findByUserIdAndBoardGameId(Long userId, Long boardGameId);
 
     int countWishByUserId(Long userId);
+
+    List<Wish> findAllByUserId(Long userId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/DaySlot.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/DaySlot.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.room.domain.constants;
 
-import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+import static com.civilwar.boardsignal.room.exception.RoomErrorCode.NOT_FOUND_DAY_SLOT;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ public enum DaySlot {
         return Arrays.stream(values())
             .filter(category -> category.isEqual(input))
             .findAny()
-            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME));
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_DAY_SLOT));
     }
 
     private boolean isEqual(String input) {

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/TimeSlot.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/TimeSlot.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.room.domain.constants;
 
-import static com.civilwar.boardsignal.boardgame.exception.BoardGameErrorCode.NOT_FOUND_BOARD_GAME;
+import static com.civilwar.boardsignal.room.exception.RoomErrorCode.NOT_FOUND_TIME_SLOT;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ public enum TimeSlot {
         return Arrays.stream(values())
             .filter(category -> category.isEqual(input))
             .findAny()
-            .orElseThrow(() -> new NotFoundException(NOT_FOUND_BOARD_GAME));
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_TIME_SLOT));
     }
 
     private boolean isEqual(String input) {

--- a/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RoomErrorCode implements ErrorCode {
 
-    NOT_FOUND_ROOM("해당 모임을 찾을 수 없습니다", "R_001");
+    NOT_FOUND_ROOM("해당 모임을 찾을 수 없습니다.", "R_001"),
+    NOT_FOUND_TIME_SLOT("시간대 값이 잘못 되었습니다.", "R_002"),
+    NOT_FOUND_DAY_SLOT("날짜 값이 잘못 되었습니다.", "R_003");
 
 
     private final String message;

--- a/core/src/test/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptorTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/boardgame/infrastructure/adaptor/BoardGameQueryRepositoryAdaptorTest.java
@@ -219,4 +219,18 @@ class BoardGameQueryRepositoryAdaptorTest extends DataJpaTestSupport {
             () -> assertThat(secondGame.getTitle()).isEqualTo(boardGame2.getTitle())
         );
     }
+
+    @Test
+    @DisplayName("[보드게임 아이디 리스트안에 속하는 보드게임을 전체 조회할 수 있다.]")
+    void findAllInIds() {
+        PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
+        Slice<BoardGame> boardGames = boardGameQueryAdaptor.findAllInIds(
+            List.of(boardGame.getId(), boardGame2.getId()),
+            pageRequest
+        );
+
+        List<BoardGame> gameList = boardGames.getContent();
+
+        assertThat(gameList).contains(boardGame).contains(boardGame2);
+    }
 }


### PR DESCRIPTION
- closed #71 

### ⛏ 작업 상세 내용

- 찜 목록 조회는 인증된 사용자만 타인의 찜목록, 내 찜 목록 조회 가능
- userId를 통해 user의 찜 전체 조회
- 조회된 찜의 보드게임id들을 추출하여 보드게임들을 in 쿼리로 조회
- 조회 결과 리턴
- Security Config 수정 
    - 스웨거 permitAll()
    - 찜 목록 조회 인증 필요 

### ✅ 중점적으로 리뷰 할 부분

- 비즈니스 로직
- 테스트 로직

### 참고사항
