### PR TITLE
edit : 현재 사용자의 정보 조회 시, 나이도 함께 반환한다.

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/dto/response/LoginUserInfoResponse.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/dto/response/LoginUserInfoResponse.java
@@ -4,6 +4,7 @@ public record LoginUserInfoResponse(
     Long id,
     String email,
     String nickname,
+    int age,
     String ageGroup,
     String gender,
     Boolean isJoined

--- a/api/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthApiMapper.java
@@ -35,6 +35,7 @@ public final class AuthApiMapper {
         Long id,
         String email,
         String nickname,
+        int age,
         String ageGroup,
         String gender,
         Boolean isJoined
@@ -43,6 +44,7 @@ public final class AuthApiMapper {
             id,
             email,
             nickname,
+            age,
             ageGroup,
             gender,
             isJoined

--- a/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URI;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -79,10 +80,16 @@ public class AuthApiController {
     public ResponseEntity<LoginUserInfoResponse> getLoginUserInfo(
         @AuthenticationPrincipal User loginUser) {
 
+        int currentYear = LocalDate.now().getYear();
+        int birthYear = loginUser.getBirth();
+        //로그인 유저 나이
+        int myAge = currentYear - birthYear + 1;
+
         LoginUserInfoResponse loginUserInfoResponse = AuthApiMapper.toLoginUserInfoResponse(
             loginUser.getId(),
             loginUser.getEmail(),
             loginUser.getNickname(),
+            myAge,
             loginUser.getAgeGroup().getDescription(),
             loginUser.getGender().getDescription(),
             loginUser.getIsJoined()

--- a/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.auth.presentation;
 
+import static org.mockito.BDDMockito.*;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -15,9 +16,12 @@ import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
+import java.time.LocalDateTime;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @DisplayName("[AuthApiController 테스트]")
 class AuthApiControllerTest extends ApiTestSupport {
@@ -27,6 +31,8 @@ class AuthApiControllerTest extends ApiTestSupport {
     private UserRepository userRepository;
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    private Supplier<LocalDateTime> nowTime;
 
     @Test
     @DisplayName("[Cookie에 담긴 RefreshToken ID를 통해 AccessToken을 재발급 받는다]")
@@ -88,6 +94,12 @@ class AuthApiControllerTest extends ApiTestSupport {
     @Test
     @DisplayName("[AccessToken의 사용자 정보를 반환한다.]")
     void getLoginUserInfoTest() throws Exception {
+        //given
+        LocalDateTime now = LocalDateTime.of(2024,3,4,9,27,0);
+        given(nowTime.get()).willReturn(now);
+
+        int expectedAge = nowTime.get().getYear() - loginUser.getBirth() + 1;
+
         //then
         mockMvc.perform(get("/api/v1/auth")
                 .header(AUTHORIZATION, accessToken))
@@ -96,7 +108,8 @@ class AuthApiControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.nickname").value(loginUser.getNickname()))
             .andExpect(jsonPath("$.ageGroup").value(loginUser.getAgeGroup().getDescription()))
             .andExpect(jsonPath("$.gender").value(loginUser.getGender().getDescription()))
-            .andExpect(jsonPath("$.isJoined").value(loginUser.getIsJoined()));
+            .andExpect(jsonPath("$.isJoined").value(loginUser.getIsJoined()))
+            .andExpect(jsonPath("$.age").value(expectedAge));
     }
 
     @Test


### PR DESCRIPTION
- closed #70

### ⛏ 작업 상세 내용

- 현재 사용자의 나이도 함께 조회할 수 있습니다!

### ✅ 중점적으로 리뷰 할 부분

- 현재 나이 계산 로직

### 참고사항
- 응답 필드만 추가된 간단한 작업입니다!