### PR TITLE
feat : 모임 확정 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
@@ -61,7 +61,7 @@ public class AuthApiController {
 
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
-            if(cookie.getName().equals(REFRESHTOKEN_NAME)) {
+            if (cookie.getName().equals(REFRESHTOKEN_NAME)) {
                 refreshTokenId = cookie.getValue();
             }
         }

--- a/api/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomApiMapper.java
@@ -1,6 +1,8 @@
 package com.civilwar.boardsignal.room.dto.mapper;
 
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.request.ApiFixRoomRequest;
+import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -29,6 +31,17 @@ public final class RoomApiMapper {
             request.categories(),
             request.isAllowedOppositeGender(),
             image
+        );
+    }
+
+    public static FixRoomRequest toFixRoomRequest(ApiFixRoomRequest request) {
+        return new FixRoomRequest(
+            request.meetingTime(),
+            request.weekDay(),
+            request.peopleCount(),
+            request.line(),
+            request.station(),
+            request.meetingPlace()
         );
     }
 }

--- a/api/src/main/java/com/civilwar/boardsignal/room/dto/request/ApiFixRoomRequest.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/dto/request/ApiFixRoomRequest.java
@@ -1,0 +1,14 @@
+package com.civilwar.boardsignal.room.dto.request;
+
+import java.time.LocalDateTime;
+
+public record ApiFixRoomRequest(
+    LocalDateTime meetingTime,
+    String weekDay,
+    int peopleCount,
+    String line,
+    String station,
+    String meetingPlace
+) {
+
+}

--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -3,9 +3,12 @@ package com.civilwar.boardsignal.room.presentation;
 import com.civilwar.boardsignal.room.application.RoomService;
 import com.civilwar.boardsignal.room.dto.mapper.RoomApiMapper;
 import com.civilwar.boardsignal.room.dto.request.ApiCreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.request.ApiFixRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
+import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
@@ -22,6 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -85,5 +89,19 @@ public class RoomController {
     ) {
         RoomInfoResponse roomInfo = roomService.findRoomInfo(user, roomId);
         return ResponseEntity.ok(roomInfo);
+    }
+
+    @Operation(summary = "모임 확정 API(방장용)")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/fix/{roomId}")
+    public ResponseEntity<FixRoomResponse> fixRoom(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        @PathVariable("roomId") Long roomId,
+        @RequestBody ApiFixRoomRequest request
+    ) {
+        FixRoomRequest fixRoomRequest = RoomApiMapper.toFixRoomRequest(request);
+        FixRoomResponse response = roomService.fixRoom(user, roomId, fixRoomRequest);
+        return ResponseEntity.ok(response);
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/common/support/ApiTestSupport.java
+++ b/api/src/test/java/com/civilwar/boardsignal/common/support/ApiTestSupport.java
@@ -10,6 +10,7 @@ import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,7 @@ public abstract class ApiTestSupport extends TestContainerSupport {
     private TokenProvider tokenProvider;
 
     protected String toJson(Object object) throws JsonProcessingException {
+        objectMapper.registerModule(new JavaTimeModule());
         return objectMapper.writeValueAsString(object);
     }
 

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -31,13 +31,11 @@ import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.function.Supplier;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,14 +66,6 @@ class RoomControllerTest extends ApiTestSupport {
     private MeetingInfoJpaRepository meetingInfoRepository;
     @MockBean
     private Supplier<LocalDateTime> nowTime;
-
-    private Room room;
-
-    @BeforeEach
-    void setUp() throws IOException {
-        room = RoomFixture.getRoom(Gender.MALE);
-        roomRepository.save(room);
-    }
 
     @Test
     @DisplayName("[사용자는 방을 생성할 수 있다.]")
@@ -372,7 +362,7 @@ class RoomControllerTest extends ApiTestSupport {
         participantRepository.save(participant);
 
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
-            LocalDateTime.of(2024, 02, 26, 20, 3, 59));
+            LocalDateTime.of(2024, 2, 26, 20, 3, 59));
         meetingInfoRepository.save(meetingInfo);
         room.fixRoom(meetingInfo);
         roomRepository.save(room);
@@ -410,7 +400,7 @@ class RoomControllerTest extends ApiTestSupport {
         participantRepository.save(participant);
 
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(
-            LocalDateTime.of(2024, 02, 26, 20, 3, 59));
+            LocalDateTime.of(2024, 2, 26, 20, 3, 59));
         meetingInfoRepository.save(meetingInfo);
         room.fixRoom(meetingInfo);
         roomRepository.save(room);
@@ -437,6 +427,8 @@ class RoomControllerTest extends ApiTestSupport {
     @DisplayName("[방장은 모임을 확정시킬 수 있다.]")
     void fixRoom() throws Exception {
         //given
+        Room room = RoomFixture.getRoom(Gender.MALE);
+        roomRepository.save(room);
         ApiFixRoomRequest request = new ApiFixRoomRequest(
             LocalDateTime.of(2024, 3, 31, 5, 30),
             "수요일",

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/WeekDay.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/constants/WeekDay.java
@@ -1,0 +1,33 @@
+package com.civilwar.boardsignal.room.domain.constants;
+
+import static com.civilwar.boardsignal.room.exception.RoomErrorCode.INVALID_WEEKDAY;
+
+import com.civilwar.boardsignal.common.exception.NotFoundException;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WeekDay {
+    MONDAY("월요일"),
+    TUESDAY("화요일"),
+    WEDNESDAY("수요일"),
+    THURSDAY("목요일"),
+    FRIDAY("금요일"),
+    SATURDAY("토요일"),
+    SUNDAY("일요일");
+
+    private final String description;
+
+    public static WeekDay of(String input) {
+        return Arrays.stream(values())
+            .filter(weekDay -> weekDay.isEqual(input))
+            .findAny()
+            .orElseThrow(() -> new NotFoundException(INVALID_WEEKDAY));
+    }
+
+    private boolean isEqual(String input) {
+        return input.equalsIgnoreCase(this.description);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/MeetingInfo.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/MeetingInfo.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.room.domain.entity;
 
+import com.civilwar.boardsignal.room.domain.constants.WeekDay;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -26,25 +27,37 @@ public class MeetingInfo {
     @Column(name = "MEETING_INFO_ID")
     private Long id;
 
+    @Column(name = "MEETING_INFO_MEETING_TIME")
     private LocalDateTime meetingTime;
 
+    @Column(name = "MEETING_INFO_WEEK_DAY")
+    private WeekDay weekDay;
+
+    @Column(name = "MEETING_INFO_PEOPLE_COUNT")
     private int peopleCount;
 
+    @Column(name = "MEETING_INFO_LINE")
     private String line;
 
+    @Column(name = "MEETING_INFO_STATION")
     private String station;
 
+    @Column(name = "MEETING_INFO_MEETING_PLACE")
     private String meetingPlace;
 
     @Builder(access = AccessLevel.PRIVATE)
     public MeetingInfo(
         @NonNull LocalDateTime meetingTime,
+        @NonNull String weekDay,
         @NonNull int peopleCount,
         @NonNull String line,
         @NonNull String station,
         @NonNull String meetingPlace
     ) {
+        WeekDay weekDayInfo = WeekDay.of(weekDay);
+
         this.meetingTime = meetingTime;
+        this.weekDay = weekDayInfo;
         this.peopleCount = peopleCount;
         this.line = line;
         this.station = station;
@@ -53,6 +66,7 @@ public class MeetingInfo {
 
     public static MeetingInfo of(
         LocalDateTime meetingTime,
+        String weekday,
         int peopleCount,
         String line,
         String station,
@@ -60,6 +74,7 @@ public class MeetingInfo {
     ) {
         return MeetingInfo.builder()
             .meetingTime(meetingTime)
+            .weekDay(weekday)
             .peopleCount(peopleCount)
             .line(line)
             .station(station)

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/MeetingInfoRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/MeetingInfoRepository.java
@@ -1,0 +1,9 @@
+package com.civilwar.boardsignal.room.domain.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
+
+public interface MeetingInfoRepository {
+
+    MeetingInfo save(MeetingInfo meetingInfo);
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ParticipantRepository {
 
@@ -12,4 +13,6 @@ public interface ParticipantRepository {
     void saveAll(Collection<Participant> participants);
 
     List<ParticipantJpaDto> findParticipantByRoomId(Long roomId);
+
+    Optional<Participant> findByUserIdAndRoomId(Long userId, Long roomId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -3,9 +3,11 @@ package com.civilwar.boardsignal.room.dto.mapper;
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.room.domain.constants.DaySlot;
 import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import com.civilwar.boardsignal.room.dto.response.ParticipantResponse;
@@ -125,5 +127,9 @@ public final class RoomMapper {
             participantJpaDto.isLeader(),
             participantJpaDto.mannerScore()
         );
+    }
+
+    public static FixRoomResponse toFixRoomResponse(Room room, MeetingInfo meetingInfo) {
+        return new FixRoomResponse(room.getId(), meetingInfo.getId());
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/request/FixRoomRequest.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/request/FixRoomRequest.java
@@ -1,0 +1,15 @@
+package com.civilwar.boardsignal.room.dto.request;
+
+import java.time.LocalDateTime;
+
+public record FixRoomRequest(
+    LocalDateTime meetingTime,
+    String weekDay,
+    int peopleCount,
+    String line,
+    String station,
+    String meetingPlace
+
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/FixRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/FixRoomResponse.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+public record FixRoomResponse(
+    Long roomId,
+    Long meetingInfoId
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
@@ -8,7 +8,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RoomErrorCode implements ErrorCode {
 
-    NOT_FOUND_ROOM("해당 모임을 찾을 수 없습니다", "R_001");
+    NOT_FOUND_ROOM("해당 모임을 찾을 수 없습니다", "R_001"),
+    INVALID_PARTICIPANT("이 방에 존재하지 않는 참가자 입니다.", "R_002"),
+    INVALID_WEEKDAY("요일 형식이 잘못 되었습니다", "R_003"),
+    IS_NOT_LEADER("방장이 아닙니다", "R_004");
 
 
     private final String message;

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/MeetingInfoRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/MeetingInfoRepositoryAdaptor.java
@@ -1,0 +1,19 @@
+package com.civilwar.boardsignal.room.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
+import com.civilwar.boardsignal.room.domain.repository.MeetingInfoRepository;
+import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MeetingInfoRepositoryAdaptor implements MeetingInfoRepository {
+
+    private final MeetingInfoJpaRepository meetingInfoJpaRepository;
+
+    @Override
+    public MeetingInfo save(MeetingInfo meetingInfo) {
+        return meetingInfoJpaRepository.save(meetingInfo);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
@@ -7,6 +7,7 @@ import com.civilwar.boardsignal.room.infrastructure.repository.ParticipantJpaRep
 import com.civilwar.boardsignal.room.infrastructure.repository.ParticipantQueryJpaRepository;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -30,5 +31,10 @@ public class ParticipantRepositoryAdaptor implements ParticipantRepository {
     @Override
     public List<ParticipantJpaDto> findParticipantByRoomId(Long roomId) {
         return participantQueryJpaRepository.findParticipantByRoomId(roomId);
+    }
+
+    @Override
+    public Optional<Participant> findByUserIdAndRoomId(Long userId, Long roomId) {
+        return participantQueryJpaRepository.findByUserIdAndRoomId(userId, roomId);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantQueryJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantQueryJpaRepository.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.room.infrastructure.repository;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,6 @@ public interface ParticipantQueryJpaRepository extends JpaRepository<Participant
             + "on p.userId = u.id "
             + "where p.roomId = :roomId")
     List<ParticipantJpaDto> findParticipantByRoomId(@Param("roomId") Long roomId);
+
+    Optional<Participant> findByUserIdAndRoomId(Long userId, Long roomId);
 }

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/MeetingInfoFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/MeetingInfoFixture.java
@@ -11,7 +11,8 @@ public final class MeetingInfoFixture {
     public static MeetingInfo getMeetingInfo(LocalDateTime meetingTime) {
         return MeetingInfo.of(
             meetingTime,
-            3,
+            "토요일",
+            5,
             "2호선",
             "사당역",
             "레드버튼"

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/room/RoomFixture.java
@@ -8,6 +8,7 @@ import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.mapper.RoomMapper;
+import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomRequest;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import java.io.IOException;
@@ -86,6 +87,21 @@ public class RoomFixture {
 
     public static Participant getParticipant() {
         return Participant.of(1L, 1L, true);
+    }
+
+    public static Participant getParticipantNotLeader() {
+        return Participant.of(1L, 1L, false);
+    }
+
+    public static FixRoomRequest getFixRoomRequest() {
+        return new FixRoomRequest(
+            LocalDateTime.of(2024, 7, 12, 5, 30),
+            "토요일",
+            5,
+            "2호선",
+            "강남역",
+            "레드버튼"
+        );
     }
 
 }


### PR DESCRIPTION
- closed #72 

### ⛏ 작업 상세 내용

- MeetingInfo 엔티티에 요일 필드(enum) 추가
- 응답바디 명세 수정(MeetingInfo id도 넘겨주도록)

### ✅ 중점적으로 리뷰 할 부분

- 비즈니스 로직
- 테스트코드

### 참고사항
