### PR TITLE
feat : 알림 조회 API구현(PR 내용 꼭 확인!!)

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/handler/OAuth2LoginSuccessHandler.java
@@ -39,7 +39,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             userLoginResponse);
 
         //Cookie -> RefreshToken Id
-        ResponseCookie cookie = ResponseCookie.from(REFRESHTOKEN_NAME, userLoginResponse.token().refreshTokenId())
+        ResponseCookie cookie = ResponseCookie.from(REFRESHTOKEN_NAME,
+                userLoginResponse.token().refreshTokenId())
             .path("/")
             .httpOnly(true)
             .secure(true)

--- a/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/presentation/AuthApiController.java
@@ -61,7 +61,7 @@ public class AuthApiController {
 
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
-            if(cookie.getName().equals(REFRESHTOKEN_NAME)) {
+            if (cookie.getName().equals(REFRESHTOKEN_NAME)) {
                 refreshTokenId = cookie.getValue();
             }
         }

--- a/api/src/main/java/com/civilwar/boardsignal/notification/presentation/NotificationController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/notification/presentation/NotificationController.java
@@ -1,17 +1,22 @@
 package com.civilwar.boardsignal.notification.presentation;
 
+import com.civilwar.boardsignal.notification.application.FcmService;
 import com.civilwar.boardsignal.notification.application.NotificationService;
 import com.civilwar.boardsignal.notification.dto.request.CreateFcmTokenReequest;
 import com.civilwar.boardsignal.notification.dto.request.NotificationTestRequest;
 import com.civilwar.boardsignal.notification.dto.response.CreateFcmTokenResponse;
+import com.civilwar.boardsignal.notification.dto.response.NotificationPageResponse;
+import com.civilwar.boardsignal.notification.dto.response.NotificationResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,12 +28,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class NotificationController {
 
+    private final FcmService fcmService;
     private final NotificationService notificationService;
 
     //test용
     @PostMapping
     public ResponseEntity<String> notificationTest(NotificationTestRequest request) {
-        String response = notificationService.sendMessageTest(request);
+        String response = fcmService.sendMessageTest(request);
         return ResponseEntity.ok(response);
     }
 
@@ -42,5 +48,20 @@ public class NotificationController {
     ) {
         CreateFcmTokenResponse response = notificationService.createFcmToken(user, request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "나의 알림 목록 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/my")
+    public ResponseEntity<NotificationPageResponse<NotificationResponse>> getAllNotifications(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        Pageable pageable
+    ) {
+        NotificationPageResponse<NotificationResponse> resposne = notificationService.getAllNotifications(
+            user, pageable
+        );
+
+        return ResponseEntity.ok(resposne);
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/notification/presentation/NotificationControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/notification/presentation/NotificationControllerTest.java
@@ -1,0 +1,66 @@
+package com.civilwar.boardsignal.notification.presentation;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.civilwar.boardsignal.common.support.ApiTestSupport;
+import com.civilwar.boardsignal.notification.domain.entity.Notification;
+import com.civilwar.boardsignal.notification.domain.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+class NotificationControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private Notification notificationFirst;
+    private Notification notificationSecond;
+
+    @BeforeEach
+    void setUp() {
+        Notification notification1 = Notification.of(
+            loginUser,
+            "https~",
+            "제목1",
+            "내용1",
+            "/api/v1"
+        );
+        Notification notification2 = Notification.of(
+            loginUser,
+            "https~",
+            "제목2",
+            "내용2",
+            "/api/v1"
+        );
+
+        notificationFirst = notificationRepository.save(notification1);
+        notificationSecond = notificationRepository.save(notification2);
+    }
+
+    @Test
+    @DisplayName("[자신의 알림 목록을 전체 조회할 수 있다.]")
+    void getAllNotifications() throws Exception {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("size", "10");
+
+        mockMvc.perform(get("/api/v1/notifications/my")
+                .params(params)
+                .header(AUTHORIZATION, accessToken))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.notificationsInfos[0].notificationId").value(notificationFirst.getId()),
+                jsonPath("$.notificationsInfos[1].notificationId").value(
+                    notificationSecond.getId()),
+                jsonPath("$.size").value(10),
+                jsonPath("$.hasNext").value(false)
+            );
+
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmService.java
@@ -1,0 +1,138 @@
+package com.civilwar.boardsignal.notification.application;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpMethod.POST;
+
+import com.civilwar.boardsignal.notification.domain.entity.Notification;
+import com.civilwar.boardsignal.notification.domain.repository.NotificationRepository;
+import com.civilwar.boardsignal.notification.dto.request.NotificationTestRequest;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.entity.UserFcmToken;
+import com.civilwar.boardsignal.user.domain.repository.UserFcmTokenRepository;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmService {
+
+    private static final String FIREBASE_CONFIG_PATH = "firebase.json";
+
+    private static final String GOOGLE_API_PREFIX = "https://fcm.googleapis.com/v1/projects";
+
+    private static final String PROJECT_ID = "boardsignal-71515";
+
+    private static final String GOOGLE_API_SUFFIX = "/messages:send";
+
+    private final UserFcmTokenRepository userFcmTokenRepository;
+    private final NotificationRepository notificationRepository;
+
+    private String getAccessToken() throws IOException {
+        final GoogleCredentials googleCredentials = GoogleCredentials
+            .fromStream(new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream())
+            .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+        googleCredentials.refreshIfExpired();
+        String tokenValue = googleCredentials.getAccessToken().getTokenValue();
+        log.info("token : {}", tokenValue);
+        return tokenValue;
+    }
+
+    private HttpEntity<String> getHttpEntity(
+        String targetToken,
+        String title,
+        String body,
+        String imageUrl
+    ) throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(AUTHORIZATION, "Bearer " + getAccessToken());
+        headers.add(CONTENT_TYPE, "application/json; charset=utf-8");
+
+        JSONObject content = new JSONObject();
+        content.put("title", title);
+        content.put("body", body);
+        content.put("image", imageUrl);
+
+        JSONObject message = new JSONObject();
+        message.put("token", targetToken);
+        message.put("notification", content);
+
+        JSONObject result = new JSONObject();
+        result.put("message", message);
+
+        String requestBody = result.toString();
+
+        return new HttpEntity<>(requestBody, headers);
+    }
+
+    public void sendMessage(Notification notification) {
+        User user = notification.getUser();
+
+        //해당 user가 사용하는 기기들의 기기 토큰 모두 조회
+        List<String> tokens = user.getUserFcmTokens().stream()
+            .map(UserFcmToken::getToken)
+            .toList();
+
+        for (String token : tokens) {
+            //Request Body 생성
+            HttpEntity<String> requestEntity = null;
+            try {
+                requestEntity = getHttpEntity(
+                    token,
+                    notification.getTitle(),
+                    notification.getBody(),
+                    notification.getImageUrl()
+                );
+            } catch (IOException e) {
+                log.error(e.getMessage());
+            }
+
+            //Google Api로 알림 전송 요청
+            RestTemplate restTemplate = new RestTemplate();
+            restTemplate.exchange(
+                GOOGLE_API_PREFIX + PROJECT_ID + GOOGLE_API_SUFFIX,
+                POST,
+                requestEntity,
+                String.class
+            );
+        }
+
+    }
+
+    //test용(개발단계에서만 있고 제거 예정)
+    public String sendMessageTest(NotificationTestRequest notification) {
+        HttpEntity<String> requestEntity = null;
+
+        try {
+            requestEntity = getHttpEntity(
+                notification.targetToken(),
+                notification.title(),
+                notification.body(),
+                notification.imageUrl()
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(
+            GOOGLE_API_PREFIX + PROJECT_ID + GOOGLE_API_SUFFIX,
+            POST,
+            requestEntity,
+            String.class
+        );
+
+        return response.toString();
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/notification/application/NotificationService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/application/NotificationService.java
@@ -1,151 +1,48 @@
 package com.civilwar.boardsignal.notification.application;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.HttpMethod.POST;
-
 import com.civilwar.boardsignal.notification.domain.entity.Notification;
 import com.civilwar.boardsignal.notification.domain.repository.NotificationRepository;
+import com.civilwar.boardsignal.notification.dto.mapper.NotificationMapper;
 import com.civilwar.boardsignal.notification.dto.request.CreateFcmTokenReequest;
-import com.civilwar.boardsignal.notification.dto.request.NotificationTestRequest;
 import com.civilwar.boardsignal.notification.dto.response.CreateFcmTokenResponse;
+import com.civilwar.boardsignal.notification.dto.response.NotificationPageResponse;
+import com.civilwar.boardsignal.notification.dto.response.NotificationResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.entity.UserFcmToken;
 import com.civilwar.boardsignal.user.domain.repository.UserFcmTokenRepository;
-import com.google.auth.oauth2.GoogleCredentials;
-import java.io.IOException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.json.JSONObject;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class NotificationService {
 
-    private static final String FIREBASE_CONFIG_PATH = "firebase.json";
-
-    private static final String GOOGLE_API_PREFIX = "https://fcm.googleapis.com/v1/projects";
-
-    private static final String PROJECT_ID = "boardsignal-71515";
-
-    private static final String GOOGLE_API_SUFFIX = "/messages:send";
-
-    private final UserFcmTokenRepository userFcmTokenRepository;
     private final NotificationRepository notificationRepository;
+    private final UserFcmTokenRepository userFcmTokenRepository;
 
-    private String getAccessToken() throws IOException {
-        final GoogleCredentials googleCredentials = GoogleCredentials
-            .fromStream(new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream())
-            .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+    @Transactional(readOnly = true)
+    public NotificationPageResponse<NotificationResponse> getAllNotifications(User user,
+        Pageable pageable) {
+        Slice<NotificationResponse> notifications = notificationRepository
+            .findAllByUser(user, pageable)
+            .map(NotificationMapper::toNotificationResponse);
 
-        googleCredentials.refreshIfExpired();
-        String tokenValue = googleCredentials.getAccessToken().getTokenValue();
-        log.info("token : {}", tokenValue);
-        return tokenValue;
-    }
-
-    private HttpEntity<String> getHttpEntity(
-        String targetToken,
-        String title,
-        String body,
-        String imageUrl
-    ) throws IOException {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(AUTHORIZATION, "Bearer " + getAccessToken());
-        headers.add(CONTENT_TYPE, "application/json; charset=utf-8");
-
-        JSONObject content = new JSONObject();
-        content.put("title", title);
-        content.put("body", body);
-        content.put("image", imageUrl);
-
-        JSONObject message = new JSONObject();
-        message.put("token", targetToken);
-        message.put("notification", content);
-
-        JSONObject result = new JSONObject();
-        result.put("message", message);
-
-        String requestBody = result.toString();
-
-        return new HttpEntity<>(requestBody, headers);
-    }
-
-    public void sendMessage(Notification notification) {
-        User user = notification.getUser();
-
-        //해당 user가 사용하는 기기들의 기기 토큰 모두 조회
-        List<String> tokens = user.getUserFcmTokens().stream()
-            .map(UserFcmToken::getToken)
-            .toList();
-
-        for (String token : tokens) {
-            //Request Body 생성
-            HttpEntity<String> requestEntity = null;
-            try {
-                requestEntity = getHttpEntity(
-                    token,
-                    notification.getTitle(),
-                    notification.getBody(),
-                    notification.getImageUrl()
-                );
-            } catch (IOException e) {
-                log.error(e.getMessage());
-            }
-
-            //Google Api로 알림 전송 요청
-            RestTemplate restTemplate = new RestTemplate();
-            restTemplate.exchange(
-                GOOGLE_API_PREFIX + PROJECT_ID + GOOGLE_API_SUFFIX,
-                POST,
-                requestEntity,
-                String.class
-            );
-        }
-
+        return NotificationMapper.toNotificationPageResponse(notifications);
     }
 
     //사용자 기기 토큰 저장
+    @Transactional
     public CreateFcmTokenResponse createFcmToken(User user, CreateFcmTokenReequest request) {
         UserFcmToken userFcmToken = UserFcmToken.of(user, request.token());
         UserFcmToken savedToken = userFcmTokenRepository.save(userFcmToken);
         return new CreateFcmTokenResponse(savedToken.getId());
     }
 
+    @Transactional
     public Notification saveNotification(Notification notification) {
         return notificationRepository.save(notification);
-    }
-
-    //test용(개발단계에서만 있고 제거 예정)
-    public String sendMessageTest(NotificationTestRequest notification) {
-        HttpEntity<String> requestEntity = null;
-
-        try {
-            requestEntity = getHttpEntity(
-                notification.targetToken(),
-                notification.title(),
-                notification.body(),
-                notification.imageUrl()
-            );
-        } catch (IOException e) {
-            log.error(e.getMessage());
-        }
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> response = restTemplate.exchange(
-            GOOGLE_API_PREFIX + PROJECT_ID + GOOGLE_API_SUFFIX,
-            POST,
-            requestEntity,
-            String.class
-        );
-
-        return response.toString();
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/notification/domain/repository/NotificationRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/domain/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.notification.domain.repository;
 
 import com.civilwar.boardsignal.notification.domain.constant.NotificationStatus;
 import com.civilwar.boardsignal.notification.domain.entity.Notification;
+import com.civilwar.boardsignal.user.domain.entity.User;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -15,5 +16,7 @@ public interface NotificationRepository {
     Slice<Notification> findAll(Pageable pageable);
 
     Notification save(Notification notification);
+
+    Slice<Notification> findAllByUser(User user, Pageable pageable);
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/notification/dto/mapper/NotificationMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/dto/mapper/NotificationMapper.java
@@ -1,0 +1,30 @@
+package com.civilwar.boardsignal.notification.dto.mapper;
+
+import com.civilwar.boardsignal.notification.domain.entity.Notification;
+import com.civilwar.boardsignal.notification.dto.response.NotificationPageResponse;
+import com.civilwar.boardsignal.notification.dto.response.NotificationResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationMapper {
+
+    public static NotificationResponse toNotificationResponse(Notification notification) {
+        return new NotificationResponse(
+            notification.getId(),
+            notification.getTitle(),
+            notification.getBody(),
+            notification.getImageUrl()
+        );
+    }
+
+    public static <T> NotificationPageResponse<T> toNotificationPageResponse(Slice<T> page) {
+        return new NotificationPageResponse<>(
+            page.getContent(),
+            page.getSize(),
+            page.hasNext()
+        );
+    }
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/notification/dto/response/NotificationPageResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/dto/response/NotificationPageResponse.java
@@ -1,0 +1,11 @@
+package com.civilwar.boardsignal.notification.dto.response;
+
+import java.util.List;
+
+public record NotificationPageResponse<T>(
+    List<T> notificationsInfos,
+    int size,
+    boolean hasNext
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/notification/dto/response/NotificationResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.notification.dto.response;
+
+public record NotificationResponse(
+    Long notificationId,
+    String title,
+    String body,
+    String imageUrl
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/notification/event/NotificationEventHandler.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/event/NotificationEventHandler.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.notification.event;
 
+import com.civilwar.boardsignal.notification.application.FcmService;
 import com.civilwar.boardsignal.notification.application.NotificationService;
 import com.civilwar.boardsignal.notification.domain.entity.Notification;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +13,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class NotificationEventHandler {
 
-    private final NotificationService notificationService;
+    private final FcmService fcmService; // 외부 api 연동 서비스
+    private final NotificationService notificationService; // 알림 레포지토리 의존 서비스
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendMessage(Notification notification) {
         Notification savedNotification = notificationService.saveNotification(notification);
-        notificationService.sendMessage(savedNotification);
+        fcmService.sendMessage(savedNotification);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/adaptor/NotificationRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/adaptor/NotificationRepositoryAdaptor.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.notification.domain.constant.NotificationStatus;
 import com.civilwar.boardsignal.notification.domain.entity.Notification;
 import com.civilwar.boardsignal.notification.domain.repository.NotificationRepository;
 import com.civilwar.boardsignal.notification.infrastructure.repository.NotificationJpaRepository;
+import com.civilwar.boardsignal.user.domain.entity.User;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -34,5 +35,10 @@ public class NotificationRepositoryAdaptor implements NotificationRepository {
     @Override
     public Notification save(Notification notification) {
         return notificationJpaRepository.save(notification);
+    }
+
+    @Override
+    public Slice<Notification> findAllByUser(User user, Pageable pageable) {
+        return notificationJpaRepository.findAllByUser(user, pageable);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/repository/NotificationJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/repository/NotificationJpaRepository.java
@@ -2,10 +2,15 @@ package com.civilwar.boardsignal.notification.infrastructure.repository;
 
 import com.civilwar.boardsignal.notification.domain.constant.NotificationStatus;
 import com.civilwar.boardsignal.notification.domain.entity.Notification;
+import com.civilwar.boardsignal.user.domain.entity.User;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
 
     Optional<Notification> findByStatus(NotificationStatus status);
+
+    Slice<Notification> findAllByUser(User user, Pageable pageable);
 }

--- a/core/src/test/java/com/civilwar/boardsignal/notification/application/NotificationServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/notification/application/NotificationServiceTest.java
@@ -1,0 +1,69 @@
+package com.civilwar.boardsignal.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+
+import com.civilwar.boardsignal.notification.domain.entity.Notification;
+import com.civilwar.boardsignal.notification.domain.repository.NotificationRepository;
+import com.civilwar.boardsignal.notification.dto.response.NotificationPageResponse;
+import com.civilwar.boardsignal.notification.dto.response.NotificationResponse;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@DisplayName("[NotificationService 테스트]")
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("[자신의 알림 목록을 조회할 수 있다.]")
+    void getAllNotifications() {
+        User user = UserFixture.getUserFixture("prpr", "https");
+        Notification notification1 = Notification.of(
+            user,
+            "https",
+            "제목1",
+            "내용1",
+            "/api/v1/~~"
+        );
+        Notification notification2 = Notification.of(
+            user,
+            "https",
+            "제목2",
+            "내용2",
+            "/api/v1/~~"
+        );
+        PageRequest pageRequest = PageRequest.of(0, 5);
+
+        given(notificationRepository.findAllByUser(user, pageRequest))
+            .willReturn(new PageImpl<>(List.of(notification1, notification2)));
+
+        NotificationPageResponse<NotificationResponse> resposne = notificationService.getAllNotifications(
+            user, pageRequest);
+
+        List<NotificationResponse> contents = resposne.notificationsInfos();
+
+        assertAll(
+            () -> assertThat(contents.get(0).title()).isEqualTo(notification1.getTitle()),
+            () -> assertThat(contents.get(0).body()).isEqualTo(notification1.getBody()),
+            () -> assertThat(contents.get(1).title()).isEqualTo(notification2.getTitle()),
+            () -> assertThat(contents.get(1).body()).isEqualTo(notification2.getBody())
+        );
+    }
+
+}


### PR DESCRIPTION
- closed #31 

### ⛏ 작업 상세 내용

- 알림 조회 로직 구현
    - 알림 조회도 무한스크롤 생각해서 구현했습니다.
- 기존에 NotificationService에 외부 API 요청 보내는 코드, DB에 토큰 저장하거나 알림 엔티티 저장하는 코드 모두 같이 있었는데 외부 API요청 보내는 로직은 다른 서비스로 분리했습니다.
- **그래서 FCMService 파일은 원래 있던 외부 API 코드를 다른 파일로 분리목적으로 뺀 파일이니 안 보셔도 무방합니다!**

### ✅ 중점적으로 리뷰 할 부분

### 참고사항

- 죄송하지만.. 커밋할 때 졸면서 하다보니 순서가 엉망이더라고요.. 파일 체인지로 리뷰 권장드립니다!!
