### PR TITLE
feat : 모임 확정 취소 API 구현

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -103,5 +104,16 @@ public class RoomController {
         FixRoomRequest fixRoomRequest = RoomApiMapper.toFixRoomRequest(request);
         FixRoomResponse response = roomService.fixRoom(user, roomId, fixRoomRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "모임 확정 취소 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @DeleteMapping("/unfix/{roomId}")
+    public void unFixRoom(
+        @Parameter(hidden = true)
+        @AuthenticationPrincipal User user,
+        @PathVariable("roomId") Long roomId
+    ){
+        roomService.unFixRoom(user, roomId);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -199,4 +199,21 @@ public class RoomService {
         return RoomMapper.toFixRoomResponse(room, room.getMeetingInfo());
     }
 
+    @Transactional
+    public void unFixRoom(User user, Long roomId){
+        //방에 존재하는 참가자 인 지 검증
+        boolean isParticipant = participantRepository.existsByUserIdAndRoomId(user.getId(), roomId);
+        if(!isParticipant){
+            throw new NotFoundException(INVALID_PARTICIPANT);
+        }
+
+        Room room = roomRepository.findById(roomId)
+            .orElseThrow(() -> new NotFoundException(NOT_FOUND_ROOM));
+
+        MeetingInfo meetingInfo = room.getMeetingInfo();
+
+        meetingInfoRepository.deleteById(meetingInfo.getId());
+        room.unFixRoom();
+    }
+
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Room.java
@@ -165,4 +165,9 @@ public class Room extends BaseEntity {
         this.meetingInfo = meetingInfo;
         this.status = RoomStatus.FIX;
     }
+
+    public void unFixRoom(){
+        this.meetingInfo = null;
+        this.status = RoomStatus.NON_FIX;
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/MeetingInfoRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/MeetingInfoRepository.java
@@ -6,4 +6,6 @@ public interface MeetingInfoRepository {
 
     MeetingInfo save(MeetingInfo meetingInfo);
 
+    void deleteById(Long id);
+
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/ParticipantRepository.java
@@ -15,4 +15,6 @@ public interface ParticipantRepository {
     List<ParticipantJpaDto> findParticipantByRoomId(Long roomId);
 
     Optional<Participant> findByUserIdAndRoomId(Long userId, Long roomId);
+
+    boolean existsByUserIdAndRoomId(Long userId, Long roomId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
@@ -12,7 +12,7 @@ public enum RoomErrorCode implements ErrorCode {
     NOT_FOUND_ROOM("해당 모임을 찾을 수 없습니다", "R_001"),
     INVALID_PARTICIPANT("이 방에 존재하지 않는 참가자 입니다.", "R_002"),
     INVALID_WEEKDAY("요일 형식이 잘못 되었습니다", "R_003"),
-    IS_NOT_LEADER("방장이 아닙니다", "R_004");
+    IS_NOT_LEADER("방장이 아닙니다", "R_004"),
     NOT_FOUND_TIME_SLOT("시간대 값이 잘못 되었습니다.", "R_005"),
     NOT_FOUND_DAY_SLOT("날짜 값이 잘못 되었습니다.", "R_006");
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/MeetingInfoRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/MeetingInfoRepositoryAdaptor.java
@@ -16,4 +16,9 @@ public class MeetingInfoRepositoryAdaptor implements MeetingInfoRepository {
     public MeetingInfo save(MeetingInfo meetingInfo) {
         return meetingInfoJpaRepository.save(meetingInfo);
     }
+
+    @Override
+    public void deleteById(Long id) {
+        meetingInfoJpaRepository.deleteById(id);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/ParticipantRepositoryAdaptor.java
@@ -37,4 +37,9 @@ public class ParticipantRepositoryAdaptor implements ParticipantRepository {
     public Optional<Participant> findByUserIdAndRoomId(Long userId, Long roomId) {
         return participantQueryJpaRepository.findByUserIdAndRoomId(userId, roomId);
     }
+
+    @Override
+    public boolean existsByUserIdAndRoomId(Long userId, Long roomId) {
+        return participantQueryJpaRepository.existsByUserIdAndRoomId(userId, roomId);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantQueryJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/ParticipantQueryJpaRepository.java
@@ -21,4 +21,6 @@ public interface ParticipantQueryJpaRepository extends JpaRepository<Participant
     List<ParticipantJpaDto> findParticipantByRoomId(@Param("roomId") Long roomId);
 
     Optional<Participant> findByUserIdAndRoomId(Long userId, Long roomId);
+
+    boolean existsByUserIdAndRoomId(Long userId, Long roomId);
 }


### PR DESCRIPTION
- closed #73 

### ⛏ 작업 상세 내용

- 모임 확정 취소 API 구현
- 방 엔티티 unfix 메소드 추가
- 모임 확정 DB에서 삭제
- API 통합테스트

### ✅ 중점적으로 리뷰 할 부분

- 비즈니스 로직
- 테스트

### 참고사항

- 응답 값 없이 삭제만 해서 api 통합테스트만 진행했습니다!
