### PR TITLE
feat : 여러명에 대한 알림 처리 & 기기 토큰 저장 로직 수정

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/notification/presentation/NotificationController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/notification/presentation/NotificationController.java
@@ -1,6 +1,6 @@
 package com.civilwar.boardsignal.notification.presentation;
 
-import com.civilwar.boardsignal.notification.application.FcmService;
+import com.civilwar.boardsignal.notification.application.FcmSender;
 import com.civilwar.boardsignal.notification.application.NotificationService;
 import com.civilwar.boardsignal.notification.dto.request.CreateFcmTokenReequest;
 import com.civilwar.boardsignal.notification.dto.request.NotificationTestRequest;
@@ -29,14 +29,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class NotificationController {
 
-    private final FcmService fcmService;
+    private final FcmSender fcmSender;
     private final NotificationService notificationService;
 
     //test용
     @PostMapping
     public ResponseEntity<String> notificationTest(@RequestBody NotificationTestRequest request)
         throws IOException {
-        String response = fcmService.sendMessageTest(request);
+        String response = fcmSender.sendMessageTest(request);
         return ResponseEntity.ok(response);
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmSender.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmSender.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class FcmService {
+public class FcmSender {
 
 
     private static final String FIREBASE_CONFIG_PATH = "firebase.json";

--- a/core/src/main/java/com/civilwar/boardsignal/notification/application/NotificationService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/application/NotificationService.java
@@ -1,6 +1,9 @@
 package com.civilwar.boardsignal.notification.application;
 
+import static com.civilwar.boardsignal.notification.exception.NotificationErrorCode.ALREADY_TOKEN_EXISTS;
+
 import com.civilwar.boardsignal.common.exception.NotFoundException;
+import com.civilwar.boardsignal.common.exception.ValidationException;
 import com.civilwar.boardsignal.notification.domain.entity.Notification;
 import com.civilwar.boardsignal.notification.domain.repository.NotificationRepository;
 import com.civilwar.boardsignal.notification.dto.mapper.NotificationMapper;
@@ -40,11 +43,17 @@ public class NotificationService {
     //사용자 기기 토큰 저장
     @Transactional
     public CreateFcmTokenResponse createFcmToken(User user, CreateFcmTokenReequest request) {
+        //이미 토큰 등록되어 있으면 예외
+        userFcmTokenRepository.findByToken(request.token())
+            .ifPresent(userFcmToken -> {
+                throw new ValidationException(ALREADY_TOKEN_EXISTS);
+            });
         //영속성 컨텍스트로 User 추출
         User findUser = userRepository.findById(user.getId())
             .orElseThrow(() -> new NotFoundException(UserErrorCode.NOT_FOUND_USER));
         UserFcmToken userFcmToken = UserFcmToken.of(findUser, request.token());
         UserFcmToken savedToken = userFcmTokenRepository.save(userFcmToken);
+
         return new CreateFcmTokenResponse(savedToken.getId());
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/notification/dto/request/NotificationRequest.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/dto/request/NotificationRequest.java
@@ -1,0 +1,13 @@
+package com.civilwar.boardsignal.notification.dto.request;
+
+import java.util.List;
+
+public record NotificationRequest(
+    String title,
+    String body,
+    String imageUrl,
+    Long roomId,
+    List<Long> userIds
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/notification/exception/NotificationErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,16 @@
+package com.civilwar.boardsignal.notification.exception;
+
+import com.civilwar.boardsignal.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+    ALREADY_TOKEN_EXISTS("해당 토큰은 이미 등록되어 있습니다.", "N_001");
+
+    private final String message;
+    private final String code;
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/repository/UserFcmTokenRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/repository/UserFcmTokenRepository.java
@@ -1,9 +1,12 @@
 package com.civilwar.boardsignal.user.domain.repository;
 
 import com.civilwar.boardsignal.user.domain.entity.UserFcmToken;
+import java.util.Optional;
 
 public interface UserFcmTokenRepository {
 
     UserFcmToken save(UserFcmToken userFcmToken);
+
+    Optional<UserFcmToken> findByToken(String token);
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/adaptor/UserFcmTokenRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/adaptor/UserFcmTokenRepositoryAdaptor.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.user.infrastructure.adaptor;
 import com.civilwar.boardsignal.user.domain.entity.UserFcmToken;
 import com.civilwar.boardsignal.user.domain.repository.UserFcmTokenRepository;
 import com.civilwar.boardsignal.user.infrastructure.repository.UserFcmTokenJpaRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +16,10 @@ public class UserFcmTokenRepositoryAdaptor implements UserFcmTokenRepository {
     @Override
     public UserFcmToken save(UserFcmToken userFcmToken) {
         return userFcmTokenJpaRepository.save(userFcmToken);
+    }
+
+    @Override
+    public Optional<UserFcmToken> findByToken(String token) {
+        return userFcmTokenJpaRepository.findByToken(token);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/repository/UserFcmTokenJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/repository/UserFcmTokenJpaRepository.java
@@ -1,8 +1,10 @@
 package com.civilwar.boardsignal.user.infrastructure.repository;
 
 import com.civilwar.boardsignal.user.domain.entity.UserFcmToken;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserFcmTokenJpaRepository extends JpaRepository<UserFcmToken, Long> {
 
+    Optional<UserFcmToken> findByToken(String token);
 }


### PR DESCRIPTION
- closed #108 

### ⛏ 작업 상세 내용

- 동일한 알림이 여러명에게 가야할 경우에 대한 로직 추가(EventHandler에 구현)
    - NotificationRequest 생성
- 기기 토큰 저장 시 이미 저장되어있으면 예외 발생 로직 추가

### ✅ 중점적으로 리뷰 할 부분

- 로직 흐름

### 참고사항

- 다대다 관계인데 테이블 구조는 안 바꾸고 꼼수 느낌인 것 같은 구현을 했습니다..
- 일단은 구현목표로 진행한거니 로직에 이상 있는 지만 리뷰 부탁드립니다~!
