### PR TITLE
feat : 내가 참여중인 모임 채팅방 목록 조회 API

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -7,6 +7,7 @@ import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.KickOutUserRequest;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.ExitRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
@@ -82,6 +83,18 @@ public class RoomController {
         ExitRoomResponse exitRoomResponse = roomFacade.exitRoom(user, roomId);
 
         return ResponseEntity.ok(exitRoomResponse);
+    }
+
+    @Operation(summary = "내가 현재 참여하고 있는 모임 조회 API (채팅 목록용)")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/my/games")
+    public ResponseEntity<RoomPageResponse<ChatRoomResponse>> getMyGame(
+        @Parameter(hidden = true) @AuthenticationPrincipal User user,
+        Pageable pageable
+    ){
+        RoomPageResponse<ChatRoomResponse> myGame = roomFacade.findMyGame(user, pageable);
+
+        return ResponseEntity.ok(myGame);
     }
 
     @Operation(summary = "내가 이전에 참여한 모임 조회 API")

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/ChatMessageDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/ChatMessageDto.java
@@ -10,7 +10,7 @@ public record ChatMessageDto(
     String userImageUrl,
     String content,
     MessageType type,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'hh:mm:ss[.SSS]")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     LocalDateTime createAt
 ) {
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -382,8 +382,12 @@ public class RoomService {
         //추방
         participantRepository.deleteById(kickOutUser.getId());
 
-        return roomRepository.findById(roomId)
+        //참가자 수 감소
+        Room room = roomRepository.findByIdWithLock(roomId)
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_ROOM));
+        room.decreaseHeadCount();
+
+        return room;
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -20,6 +20,7 @@ import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.KickOutUserRequest;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.DeleteRoomFacadeResponse;
 import com.civilwar.boardsignal.room.dto.response.ExitRoomResponse;
@@ -125,11 +126,50 @@ public class RoomService {
     }
 
     @Transactional(readOnly = true)
+    public RoomPageResponse<ChatRoomResponse> findMyGame(
+        User user,
+        Pageable pageable
+    ) {
+        boolean hasNext = false;
+
+        //1. 내가 지금까지 참가한 모든 room 조회
+        List<Room> myGame = roomRepository.findMyGame(user.getId());
+
+        //2. 모임 미확정인 방 & 확정이어도 시간이 지나지 않은 방
+        List<Room> myCurrentGame = new ArrayList<>(
+            myGame.stream()
+                .filter(room -> room.getStatus().equals(RoomStatus.NON_FIX)
+                    || room.getMeetingInfo().getMeetingTime().toLocalDate()
+                    .isAfter(now.get().toLocalDate())
+                ).toList()
+        );
+
+        //3. Slicing
+        List<Room> resultList = new ArrayList<>();
+        myCurrentGame.stream()
+            .skip(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1L)
+            .forEach(resultList::add);
+
+        //4.
+        if (resultList.size() > pageable.getPageSize()) {
+            hasNext = true;
+            resultList.remove(resultList.size() - 1);
+        }
+
+        //5. slice 반환
+        Slice<Room> result = new SliceImpl<>(resultList, pageable, hasNext);
+
+        Slice<ChatRoomResponse> resultMap = result.map(RoomMapper::toChatRoomResponse);
+
+        return RoomMapper.toRoomPageResponse(resultMap);
+    }
+
+    @Transactional(readOnly = true)
     public RoomPageResponse<GetAllRoomResponse> findMyEndGame(
         Long userId,
         Pageable pageable
     ) {
-
         boolean hasNext = false;
 
         //1. 내가 참여한 모든 room
@@ -159,7 +199,9 @@ public class RoomService {
         //5. slice 변환
         Slice<Room> result = new SliceImpl<>(resultList, pageable, hasNext);
 
-        return RoomMapper.toRoomPageResponse(result);
+        Slice<GetAllRoomResponse> resultMap = result.map(RoomMapper::toGetAllRoomResponse);
+
+        return RoomMapper.toRoomPageResponse(resultMap);
     }
 
     @Transactional(readOnly = true)
@@ -168,7 +210,10 @@ public class RoomService {
         Pageable pageable
     ) {
         Slice<Room> findRooms = roomRepository.findAll(roomSearchCondition, pageable);
-        return RoomMapper.toRoomPageResponse(findRooms);
+
+        Slice<GetAllRoomResponse> findRoomsMap = findRooms.map(RoomMapper::toGetAllRoomResponse);
+
+        return RoomMapper.toRoomPageResponse(findRoomsMap);
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
@@ -16,6 +16,8 @@ public interface RoomRepository {
 
     Optional<Room> findById(Long id);
 
+    List<Room> findMyGame(Long userId);
+
     List<Room> findMyFixRoom(Long userId);
 
     Slice<Room> findAll(RoomSearchCondition roomSearchCondition, Pageable pageable);

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -6,6 +6,7 @@ import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
@@ -86,14 +87,13 @@ public final class RoomMapper {
         );
     }
 
-    public static RoomPageResponse<GetAllRoomResponse> toRoomPageResponse(Slice<Room> pages) {
-
-        Slice<GetAllRoomResponse> dto = pages.map(RoomMapper::toGetAllRoomResponse);
+    public static <T> RoomPageResponse<T> toRoomPageResponse(Slice<T> pages) {
 
         return new RoomPageResponse<>(
-            dto.getContent(),
-            dto.getSize(),
-            dto.hasNext()
+            pages.getContent(),
+            pages.getNumber(),
+            pages.getSize(),
+            pages.hasNext()
         );
     }
 
@@ -174,5 +174,13 @@ public final class RoomMapper {
             room.getHeadCount(),
             participants
         );
+    }
+
+    public static ChatRoomResponse toChatRoomResponse(Room room) {
+        return new ChatRoomResponse(
+            room.getId(),
+            room.getTitle(),
+            room.getImageUrl(),
+            room.getHeadCount());
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomResponse.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+public record ChatRoomResponse(
+    Long id,
+    String title,
+    String imageUrl,
+    int headCount
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomPageResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/RoomPageResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record RoomPageResponse<T>(
     List<T> roomsInfos,
+    int currentPageNumber,
     int size,
     boolean hasNext
 ) {

--- a/core/src/main/java/com/civilwar/boardsignal/room/facade/RoomFacade.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/facade/RoomFacade.java
@@ -9,6 +9,7 @@ import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.KickOutUserRequest;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.DeleteRoomFacadeResponse;
 import com.civilwar.boardsignal.room.dto.response.ExitRoomResponse;
@@ -71,6 +72,13 @@ public class RoomFacade {
         Long roomId
     ) {
         return roomService.exitRoom(user, roomId);
+    }
+
+    public RoomPageResponse<ChatRoomResponse> findMyGame(
+        User user,
+        Pageable pageable
+    ) {
+        return roomService.findMyGame(user, pageable);
     }
 
     public RoomPageResponse<GetAllRoomResponse> findMyEndGame(
@@ -159,6 +167,5 @@ public class RoomFacade {
 
         publisher.publishEvent(notificationRequest);
     }
-
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -104,6 +104,11 @@ public class RoomRepositoryAdaptor implements RoomRepository {
     }
 
     @Override
+    public List<Room> findMyGame(Long userId) {
+        return roomJpaRepository.findMyGame(userId);
+    }
+
+    @Override
     public List<Room> findMyFixRoom(Long userId) {
         return roomJpaRepository.findMyFixRoom(userId);
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -16,7 +16,16 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
     @Override
     Optional<Room> findById(Long roomId);
 
-    // 내가 참여한 모든 room 조회 쿼리
+    // 내가 현재 참여한 room 조회
+    @EntityGraph(attributePaths = {"meetingInfo"})
+    @Query("select r "
+        + "from Room as r "
+        + "join Participant as p "
+        + "on r.id = p.roomId "
+        + "where p.userId=:userId ")
+    List<Room> findMyGame(@Param("userId") Long userId);
+
+    // 내가 참여한 fix room 조회 쿼리
     @EntityGraph(attributePaths = {"meetingInfo"})
     @Query("select r "
         + "from Room as r "

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -606,7 +606,7 @@ class RoomServiceTest {
             Optional.of(leaderInfo));
         given(participantRepository.findByUserIdAndRoomId(userId, roomId)).willReturn(
             Optional.of(userInfo));
-        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(roomRepository.findByIdWithLock(roomId)).willReturn(Optional.of(room));
 
         KickOutUserRequest kickOutUserRequest = new KickOutUserRequest(roomId, userId);
 


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 내가 참여중인 모임 채팅방 목록 조회 API

- 채팅 시간 pattern 변경
- 방 관련 API 페이징 응답 시, page 함께 반환
- 참가자 추방 시, 참가자 수 감소

### ✅ 중점적으로 리뷰 할 부분
- 비즈니스 로직
- Controller에 적어놓은 테스트 케이스

### 참고사항

참여중인 모임 채팅방 목록 조회 API와 더불어
수정 작업도 추가적으로 진행하였습니다!

오늘 밤 내로 마지막 PR 올라갈 예정입니다!