### PR TITLE
edit : 채팅 내역 조회 시, 채팅 확인 여부 함께 반환

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/chat/presentation/ChatMessageController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/chat/presentation/ChatMessageController.java
@@ -1,8 +1,8 @@
 package com.civilwar.boardsignal.chat.presentation;
 
 import com.civilwar.boardsignal.chat.application.ChatMessageService;
-import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatPageResponse;
+import com.civilwar.boardsignal.chat.dto.response.GetChatMessageResponse;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +20,12 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
 
     @GetMapping("/api/v1/rooms/chats/{roomId}")
-    public ResponseEntity<ChatPageResponse<ChatMessageDto>> findChatMessages(
+    public ResponseEntity<ChatPageResponse<GetChatMessageResponse>> findChatMessages(
         @Parameter(hidden = true) @AuthenticationPrincipal User user,
         @PathVariable("roomId") Long roomId,
         Pageable pageable
     ) {
-        ChatPageResponse<ChatMessageDto> chatMessages = chatMessageService.findChatMessages(user,
+        ChatPageResponse<GetChatMessageResponse> chatMessages = chatMessageService.findChatMessages(user,
             roomId, pageable);
         return ResponseEntity.ok(chatMessages);
     }

--- a/api/src/main/java/com/civilwar/boardsignal/chat/presentation/StompMessageController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/chat/presentation/StompMessageController.java
@@ -9,6 +9,7 @@ import com.civilwar.boardsignal.chat.dto.ApiChatMessageRequest;
 import com.civilwar.boardsignal.chat.dto.request.ChatMessageRequest;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageResponse;
 import com.civilwar.boardsignal.chat.mapper.ChatMessageApiMapper;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -27,17 +28,20 @@ public class StompMessageController {
     private final ChatMessageService chatMessageService;
     private final SimpMessageSendingOperations simpMessageSendingOperations;
 
+    //AccessToken -> UserId 조회
+    private Long getUserId(String token) {
+        String accessToken = token.split(" ")[1];
+        TokenPayload payLoad = jwtTokenProvider.getPayLoad(accessToken);
+        return  payLoad.userId();
+    }
+
     @MessageMapping("/chats/{roomId}")
     public void sendMessage(
         @DestinationVariable(value = "roomId") Long roomId,
         @Header(AUTHORIZATION) String token,
         @Payload ApiChatMessageRequest apiChatMessageRequest
     ) {
-
-        //AccessToken -> UserId 조회
-        String accessToken = token.split(" ")[1];
-        TokenPayload payLoad = jwtTokenProvider.getPayLoad(accessToken);
-        Long userId = payLoad.userId();
+        Long userId = getUserId(token);
 
         log.info("roomId = {}, userId = {}, request.content = {}, request.type = {}",
             roomId, userId, apiChatMessageRequest.content(), apiChatMessageRequest.type());
@@ -50,5 +54,19 @@ public class StompMessageController {
         //채팅 전송
         simpMessageSendingOperations.convertAndSend("/topic/chats/" + roomId, chatMessageResponse);
     }
+
+    //Disconnect 시키기 전, 프론트에서 송신할 메시지 경로
+    @MessageMapping("/chats/exit/{roomId}")
+    public void exit(
+        @DestinationVariable(value = "roomId") Long roomId,
+        @Header(AUTHORIZATION) String token
+    ) {
+        Long userId = getUserId(token);
+
+        LocalDateTime exitTime = chatMessageService.exitChatRoom(userId, roomId);
+
+        log.info("User Exit Time -> {}", exitTime);
+    }
+
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/ChatMessageDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/ChatMessageDto.java
@@ -1,7 +1,6 @@
 package com.civilwar.boardsignal.chat.dto.response;
 
 import com.civilwar.boardsignal.chat.domain.constant.MessageType;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record ChatMessageDto(
@@ -10,8 +9,7 @@ public record ChatMessageDto(
     String userImageUrl,
     String content,
     MessageType type,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
-    LocalDateTime createAt
+    LocalDateTime createdAt
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/GetChatMessageResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/GetChatMessageResponse.java
@@ -1,0 +1,18 @@
+package com.civilwar.boardsignal.chat.dto.response;
+
+import com.civilwar.boardsignal.chat.domain.constant.MessageType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record GetChatMessageResponse(
+    Long userId,
+    String nickname,
+    String userImageUrl,
+    String content,
+    MessageType type,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    LocalDateTime createdAt,
+    Boolean isChecked
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/chat/mapper/ChatMessageMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/mapper/ChatMessageMapper.java
@@ -4,6 +4,8 @@ import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageResponse;
 import com.civilwar.boardsignal.chat.dto.response.ChatPageResponse;
+import com.civilwar.boardsignal.chat.dto.response.GetChatMessageResponse;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -12,12 +14,31 @@ import org.springframework.data.domain.Slice;
 public final class ChatMessageMapper {
 
     public static ChatMessageResponse toChatMessageResponse(ChatMessage chatMessage) {
-        return new ChatMessageResponse(chatMessage.getUserId(), chatMessage.getContent(),
-            chatMessage.getMessageType(), chatMessage.getCreatedAt());
+        return new ChatMessageResponse(
+            chatMessage.getUserId(),
+            chatMessage.getContent(),
+            chatMessage.getMessageType(),
+            chatMessage.getCreatedAt()
+        );
     }
 
-    public static ChatPageResponse<ChatMessageDto> toChatPageResponse(
-        Slice<ChatMessageDto> slices) {
+    public static GetChatMessageResponse toGetChatMessageResponse(
+        ChatMessageDto chatMessageDto,
+        LocalDateTime lastExitTime
+    ) {
+        return new GetChatMessageResponse(
+            chatMessageDto.userId(),
+            chatMessageDto.nickname(),
+            chatMessageDto.userImageUrl(),
+            chatMessageDto.content(),
+            chatMessageDto.type(),
+            chatMessageDto.createdAt(),
+            lastExitTime.isAfter(chatMessageDto.createdAt())
+        );
+    }
+
+    public static <T> ChatPageResponse<T> toChatPageResponse(
+        Slice<T> slices) {
 
         return new ChatPageResponse<>(
             slices.getContent(),

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -81,6 +81,7 @@ public class RoomService {
             savedRoom.getId(),
             true // 방 생성자가 방장여부는 true
         ); // 나중에 방 폭파 때 해당 방의 Participant 전부 삭제
+        participant.updateLastExit(now.get());
         participantRepository.save(participant);
 
         return RoomMapper.toCreateRoomResponse(savedRoom);

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -81,7 +81,6 @@ public class RoomService {
             savedRoom.getId(),
             true // 방 생성자가 방장여부는 true
         ); // 나중에 방 폭파 때 해당 방의 Participant 전부 삭제
-        participant.updateLastExit(now.get());
         participantRepository.save(participant);
 
         return RoomMapper.toCreateRoomResponse(savedRoom);
@@ -103,6 +102,7 @@ public class RoomService {
         //참여 정보 저장
         Participant participant = Participant.of(user.getId(), roomId, false);
         participantRepository.save(participant);
+        participant.updateLastExit(now.get());
 
         return new ParticipantRoomResponse(findRoom.getHeadCount());
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Participant.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Participant.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +32,9 @@ public class Participant {
     @Column(name = "PARTICIPANT_IS_LEADER")
     private boolean isLeader;
 
+    @Column(name = "PARTICIPANT_LAST_EXIT")
+    private LocalDateTime lastExit;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Participant(
         Long userId,
@@ -52,5 +56,9 @@ public class Participant {
             .roomId(roomId)
             .isLeader(isLeader)
             .build();
+    }
+
+    public void updateLastExit(LocalDateTime exitTime) {
+        this.lastExit = exitTime;
     }
 }


### PR DESCRIPTION
- closed #135 

### ⛏ 작업 상세 내용

- Participant에 채팅 페이지 퇴장 시간이 함께 기록됩니다
- 채팅 페이지 퇴장 시간은 프론트에서 별도의 메시지 송신으로 기록됩니다
- 채팅 내역 조회 시, 각각의 채팅이 이미 확인한 채팅인지 여부를 함께 반환합니다

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
- 첫 번째 커밋에서 roomservice는 안보셔도 됩니다