### PR TITLE
edit : 종료된 게임에 참여한 유저 조회 API 응답 필드 수정

### DIFF
--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -199,6 +199,7 @@ public final class RoomMapper {
             room.getMinParticipants(),
             room.getMaxParticipants(),
             categories,
+            room.getImageUrl(),
             room.getCreatedAt(),
             room.getHeadCount(),
             participants

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetEndGameUsersResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetEndGameUsersResponse.java
@@ -19,6 +19,7 @@ public record GetEndGameUsersResponse(
     int minParticipant,
     int maxParticipant,
     List<String> categories,
+    String imageUrl,
     @JsonFormat(pattern = "MM-dd'T'HH:mm:ss")
     LocalDateTime createdAt,
     int headCount,


### PR DESCRIPTION
- closed #137 

### ⛏ 작업 상세 내용

- 응답 dto에 imageUrl 추가

### ✅ 중점적으로 리뷰 할 부분

- 5초만에 리뷰 가능합니다.

### 참고사항
