### PR TITLE
feat : 모임 확정 시 날짜 검증 추가

### DIFF
--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -570,6 +570,7 @@ class RoomControllerTest extends ApiTestSupport {
         Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
         participantRepository.save(participant);
 
+        given(nowTime.get()).willReturn(request.meetingTime().minusDays(1));
         mockMvc.perform(post("/api/v1/rooms/fix/{roomId}", room.getId())
                 .header(AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.room.application;
 
+import static com.civilwar.boardsignal.room.exception.RoomErrorCode.INVALID_DATE;
 import static com.civilwar.boardsignal.room.exception.RoomErrorCode.INVALID_PARTICIPANT;
 import static com.civilwar.boardsignal.room.exception.RoomErrorCode.IS_NOT_LEADER;
 import static com.civilwar.boardsignal.room.exception.RoomErrorCode.NOT_FOUND_ROOM;
@@ -52,6 +53,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RoomService {
 
+    private static final int LIMIT_DAY = 7;
     private final RoomRepository roomRepository;
     private final ParticipantRepository participantRepository;
     private final MeetingInfoRepository meetingInfoRepository;
@@ -278,6 +280,13 @@ public class RoomService {
         Long roomId,
         FixRoomRequest request
     ) {
+        LocalDateTime today = now.get(); // 오늘
+        LocalDateTime fixDay = request.meetingTime(); // 모임 확정하려는 날짜
+        //오늘보다 이전 날짜거나 7일 이후를 확정시에 예외
+        if(fixDay.isBefore(today) || fixDay.isAfter(today.plusDays(LIMIT_DAY))){
+            throw new ValidationException(INVALID_DATE);
+        }
+
         //방에 존재하는 참가자 인 지 검증
         Participant participant = participantRepository.findByUserIdAndRoomId(user.getId(), roomId)
             .orElseThrow(() -> new NotFoundException(INVALID_PARTICIPANT));

--- a/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
@@ -14,7 +14,8 @@ public enum RoomErrorCode implements ErrorCode {
     IS_NOT_LEADER("방장이 아닙니다", "R_003"),
     NOT_FOUND_TIME_SLOT("시간대 값이 잘못 되었습니다.", "R_004"),
     NOT_FOUND_DAY_SLOT("날짜 값이 잘못 되었습니다.", "R_005"),
-    ALREADY_PARTICIPANT("이미 모임에 참여하였습니다", "R_006");
+    ALREADY_PARTICIPANT("이미 모임에 참여하였습니다", "R_006"),
+    INVALID_DATE("오늘보다 이전 날짜로 잘못된 날짜입니다.", "R_007");
 
 
     private final String message;

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -329,6 +329,7 @@ class RoomServiceTest {
             LocalDateTime.of(2024, 7, 31, 5, 30)
         );
         ReflectionTestUtils.setField(meetingInfo, "id", 1L);
+        FixRoomRequest request = RoomFixture.getFixRoomRequest();
 
         given(participantRepository.findByUserIdAndRoomId(user.getId(), room.getId()))
             .willReturn(Optional.of(participant));
@@ -336,8 +337,8 @@ class RoomServiceTest {
             .willReturn(Optional.of(room));
         given(meetingInfoRepository.save(any(MeetingInfo.class)))
             .willReturn(meetingInfo);
+        given(time.get()).willReturn(request.meetingTime().minusDays(1));
 
-        FixRoomRequest request = RoomFixture.getFixRoomRequest();
 
         //when
         Room response = roomService.fixRoom(user, room.getId(), request);
@@ -362,6 +363,7 @@ class RoomServiceTest {
 
         given(participantRepository.findByUserIdAndRoomId(any(Long.class), any(Long.class)))
             .willReturn(Optional.empty());
+        given(time.get()).willReturn(request.meetingTime().minusDays(1));
 
         //when
         ThrowingCallable when = () -> roomService.fixRoom(user, 1L, request);
@@ -385,6 +387,7 @@ class RoomServiceTest {
 
         given(participantRepository.findByUserIdAndRoomId(any(Long.class), any(Long.class)))
             .willReturn(Optional.of(participantNotLeader));
+        given(time.get()).willReturn(request.meetingTime().minusDays(1));
 
         //when
         ThrowingCallable when = () -> roomService.fixRoom(user, 1L, request);

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -672,4 +672,41 @@ class RoomServiceTest {
         assertThatThrownBy(() -> roomService.kickOutUser(leader, kickOutUserRequest)).isInstanceOf(
             ValidationException.class).hasMessage(RoomErrorCode.INVALID_PARTICIPANT.getMessage());
     }
+
+    @Test
+    @DisplayName("[모임 확정 시, 확정 시점보다 이전으로 확정하려 할 시 예외가 발생한다.]")
+    void fixRoomBeforeDate(){
+        //given
+        User user = UserFixture.getUserFixture("rprp", "https");
+        FixRoomRequest request = RoomFixture.getFixRoomRequest();
+        LocalDateTime today = request.meetingTime().plusDays(1);
+        given(time.get()).willReturn(today);
+
+        //when
+        ThrowingCallable when = () -> roomService.fixRoom(user, 1L, request);
+
+        //then
+        assertThatThrownBy(when)
+            .isInstanceOf(ValidationException.class)
+            .hasMessageContaining(RoomErrorCode.INVALID_DATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("[모임 확정 시, 확정 시점 7일 이후에 대한 요청이 오면 예외가 발생한다.]")
+    void fixRoomAfterSevenDays(){
+        //given
+        User user = UserFixture.getUserFixture("rprp", "https");
+        FixRoomRequest request = RoomFixture.getFixRoomRequest();
+        LocalDateTime today = request.meetingTime().minusDays(8);
+
+        given(time.get()).willReturn(today);
+
+        //when
+        ThrowingCallable when = () -> roomService.fixRoom(user, 1L, request);
+
+        //then
+        assertThatThrownBy(when)
+            .isInstanceOf(ValidationException.class)
+            .hasMessageContaining(RoomErrorCode.INVALID_DATE.getMessage());
+    }
 }


### PR DESCRIPTION
- closed #143 

### ⛏ 작업 상세 내용

- 확정 날짜가 요청 시점보다 이전이면 예외
- 확정 날짜가 요청 시점 7일이내가 아닐 경우 예외
- Service 테스트 추가

### ✅ 중점적으로 리뷰 할 부분

- 추가된 검증 로직
- 테스트 코드

### 참고사항
