### PR TITLE
feat : 내가 이전에 참여한 모임 조회 시, 해당 모임에 리뷰 반영 여부를 함께 반환한다

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/handler/OAuth2LoginSuccessHandler.java
@@ -25,7 +25,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final String DOMAIN = "http://localhost:5173";
+    private final String DOMAIN = "https://team-civilwar-boardsignal-fe.pages.dev";
     private final String REFRESHTOKEN_NAME = "RefreshToken_Id";
 
     private final AuthService authService;

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -393,17 +393,25 @@ class RoomControllerTest extends ApiTestSupport {
         //방 생성
         Room room = RoomFixture.getRoom(Gender.UNION);
         roomRepository.save(room);
+        Room room2 = RoomFixture.getRoom(Gender.UNION);
+        roomRepository.save(room2);
 
         //방 참가
-        Participant participant = Participant.of(loginUser.getId(), room.getId(), true);
-        participantRepository.save(participant);
-        Participant.of(anotherUser.getId(), room.getId(), false);
+        participantRepository.save(Participant.of(loginUser.getId(), room.getId(), true));
+        participantRepository.save(Participant.of(anotherUser.getId(), room.getId(), false));
+
+        participantRepository.save(Participant.of(loginUser.getId(), room2.getId(), true));
+        participantRepository.save(Participant.of(anotherUser.getId(), room2.getId(), false));
 
         //모임 확정
         MeetingInfo meetingInfo = MeetingInfoFixture.getMeetingInfo(before);
         meetingInfoRepository.save(meetingInfo);
         room.fixRoom(meetingInfo);
         roomRepository.save(room);
+        MeetingInfo meetingInfo2 = MeetingInfoFixture.getMeetingInfo(before);
+        meetingInfoRepository.save(meetingInfo2);
+        room2.fixRoom(meetingInfo2);
+        roomRepository.save(room2);
 
         //리뷰 등록
         Review review = ReviewFixture.getReviewFixture(loginUser.getId(), anotherUser.getId(),
@@ -419,10 +427,11 @@ class RoomControllerTest extends ApiTestSupport {
                 .params(params))
             .andExpect(jsonPath("$.size").value(5))
             .andExpect(jsonPath("$.hasNext").value(false))
-            .andExpect(jsonPath("$.roomsInfos.length()").value(1))
+            .andExpect(jsonPath("$.roomsInfos.length()").value(2))
             .andExpect(jsonPath("$.roomsInfos.[0].fixTime").value(
                 before.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
-            .andExpect(jsonPath("$.roomsInfos[0].reviewCompleted").value(true));
+            .andExpect(jsonPath("$.roomsInfos[0].reviewCompleted").value(true))
+            .andExpect(jsonPath("$.roomsInfos[1].reviewCompleted").value(false));
     }
 
     @Disabled

--- a/core/src/main/java/com/civilwar/boardsignal/review/application/ReviewService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/application/ReviewService.java
@@ -1,6 +1,7 @@
 package com.civilwar.boardsignal.review.application;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
+import com.civilwar.boardsignal.common.exception.ValidationException;
 import com.civilwar.boardsignal.review.domain.constant.ReviewContent;
 import com.civilwar.boardsignal.review.domain.constant.ReviewRecommend;
 import com.civilwar.boardsignal.review.domain.entity.Review;
@@ -9,6 +10,7 @@ import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
 import com.civilwar.boardsignal.review.dto.request.ReviewEvaluationDto;
 import com.civilwar.boardsignal.review.dto.request.ReviewSaveRequest;
 import com.civilwar.boardsignal.review.dto.response.ReviewSaveResponse;
+import com.civilwar.boardsignal.review.exception.ReviewErrorCode;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import com.civilwar.boardsignal.user.exception.UserErrorCode;
@@ -31,6 +33,11 @@ public class ReviewService {
         User loginUser,
         Long roomId
     ) {
+
+        if(reviewRepository.existsReviewByReviewerIdAndRoomId(loginUser.getId(), roomId)) {
+            throw new ValidationException(ReviewErrorCode.ALREADY_EXIST_REVIEW);
+        }
+
         //유저가 남긴 리뷰 id 저장
         List<Long> reviewIds = new ArrayList<>();
 

--- a/core/src/main/java/com/civilwar/boardsignal/review/domain/repository/ReviewRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/domain/repository/ReviewRepository.java
@@ -13,4 +13,8 @@ public interface ReviewRepository {
     List<Review> findAll();
 
     List<Review> findReviewsByRevieweeId(Long userId);
+
+    List<Review> findReviewsByRoomIdsAndReviewer(List<Long> roomIds, Long reviewer);
+
+    boolean existsReviewByReviewerIdAndRoomId(Long reviewerId, Long roomId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/review/exception/ReviewErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/exception/ReviewErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements ErrorCode {
 
-    NOT_FOUND_CONTENT("존재하지 않는 리뷰 항목입니다", "R_001");
+    NOT_FOUND_CONTENT("존재하지 않는 리뷰 항목입니다", "R_001"),
+    ALREADY_EXIST_REVIEW("해당 모임에 이미 리뷰하였습니다", "R_002");
 
 
     private final String message;

--- a/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/adaptor/ReviewRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/adaptor/ReviewRepositoryAdaptor.java
@@ -33,4 +33,14 @@ public class ReviewRepositoryAdaptor implements ReviewRepository {
     public List<Review> findReviewsByRevieweeId(Long userId) {
         return reviewJpaRepository.findReviewsByRevieweeId(userId);
     }
+
+    @Override
+    public List<Review> findReviewsByRoomIdsAndReviewer(List<Long> roomIds, Long reviewer) {
+        return reviewJpaRepository.findReviewsByRoomIdsAndReviewer(roomIds, reviewer);
+    }
+
+    @Override
+    public boolean existsReviewByReviewerIdAndRoomId(Long reviewerId, Long roomId) {
+        return reviewJpaRepository.existsReviewByReviewerIdAndRoomId(reviewerId, roomId);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepository.java
@@ -12,4 +12,10 @@ public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
         + "where r.revieweeId = :userId")
     List<Review> findReviewsByRevieweeId(@Param("userId") Long userId);
 
+    @Query("select r from Review as r "
+        + "where r.reviewerId = :reviewerId "
+        + "and r.roomId in :roomIds ")
+    List<Review> findReviewsByRoomIdsAndReviewer(@Param("roomIds") List<Long> roomIds, @Param("reviewerId") Long reviewerId);
+
+    boolean existsReviewByReviewerIdAndRoomId(Long reviewerId, Long roomId);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -8,6 +8,8 @@ import com.civilwar.boardsignal.chat.domain.repository.ChatMessageRepository;
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import com.civilwar.boardsignal.common.exception.ValidationException;
 import com.civilwar.boardsignal.image.domain.ImageRepository;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
 import com.civilwar.boardsignal.room.domain.constants.RoomStatus;
 import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
@@ -53,6 +55,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final ReviewRepository reviewRepository;
     private final ParticipantRepository participantRepository;
     private final MeetingInfoRepository meetingInfoRepository;
     private final ChatMessageRepository chatMessageRepository;
@@ -200,10 +203,20 @@ public class RoomService {
             resultList.remove(resultList.size() - 1);
         }
 
+        // 내가 참여한 종료된 모임의 id 리스트
+        List<Long> myEndGameIds = resultList.stream()
+            .map(Room::getId)
+            .toList();
+
+        // 자신이 참여한 종료된 모임들에 작성한 리뷰들
+        List<Review> myEndGameReview = reviewRepository.findReviewsByRoomIdsAndReviewer(
+            myEndGameIds, userId);
+
         //5. slice 변환
         Slice<Room> result = new SliceImpl<>(resultList, pageable, hasNext);
 
-        Slice<GetEndGameResponse> resultMap = result.map(RoomMapper::toGetEndGameResponse);
+        Slice<GetEndGameResponse> resultMap = result.map(
+            room -> RoomMapper.toGetEndGameResponse(room, myEndGameReview));
 
         return RoomMapper.toRoomPageResponse(resultMap);
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -19,6 +19,7 @@ import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -106,7 +107,8 @@ public final class RoomMapper {
             .map(Review::getRoomId).toList();
 
         //현재 방이 리뷰 완료한 방인지 확인
-        boolean reviewCompleted= reviewRoomIds.stream().anyMatch(reviewRoomIds::contains);
+        boolean reviewCompleted= reviewRoomIds.stream()
+            .anyMatch(reviewRoomId -> Objects.equals(reviewRoomId, room.getId()));
 
         return new GetEndGameResponse(
             room.getId(),

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -1,6 +1,7 @@
 package com.civilwar.boardsignal.room.dto.mapper;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.review.domain.entity.Review;
 import com.civilwar.boardsignal.room.domain.constants.DaySlot;
 import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
@@ -88,7 +89,8 @@ public final class RoomMapper {
         );
     }
 
-    public static GetEndGameResponse toGetEndGameResponse(Room room) {
+    public static GetEndGameResponse toGetEndGameResponse(Room room,
+        List<Review> userReviews) {
         List<String> categories = room.getRoomCategories().stream()
             .map(roomCategory -> roomCategory.getCategory().getDescription())
             .toList();
@@ -98,6 +100,13 @@ public final class RoomMapper {
         log.info("{}", station);
 
         MeetingInfo fixMeetingInfo = room.getMeetingInfo();
+
+        // 유저가 완료한 리뷰의 방 id 리스트
+        List<Long> reviewRoomIds = userReviews.stream()
+            .map(Review::getRoomId).toList();
+
+        //현재 방이 리뷰 완료한 방인지 확인
+        boolean reviewCompleted= reviewRoomIds.stream().anyMatch(reviewRoomIds::contains);
 
         return new GetEndGameResponse(
             room.getId(),
@@ -117,7 +126,8 @@ public final class RoomMapper {
             room.getMeetingInfo().getMeetingTime(),
             fixMeetingInfo.getLine(),
             fixMeetingInfo.getStation(),
-            fixMeetingInfo.getMeetingPlace()
+            fixMeetingInfo.getMeetingPlace(),
+            reviewCompleted
         );
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetEndGameResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/GetEndGameResponse.java
@@ -24,7 +24,8 @@ public record GetEndGameResponse(
     LocalDateTime fixTime,
     String fixLine,
     String fixStation,
-    String fixPlace
+    String fixPlace,
+    boolean reviewCompleted
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/dto/response/LoginUserInfoResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/dto/response/LoginUserInfoResponse.java
@@ -14,7 +14,8 @@ public record LoginUserInfoResponse(
     Boolean isJoined,
     String subwayLine,
     String subwayStation,
-    List<String> categories
+    List<String> categories,
+    String profileImageUrl
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/mapper/UserMapper.java
@@ -60,7 +60,8 @@ public final class UserMapper {
             loginUser.getStation(),
             categories.stream()
                 .map(Category::getDescription)
-                .toList()
+                .toList(),
+            loginUser.getProfileImageUrl()
         );
     }
 

--- a/core/src/test/java/com/civilwar/boardsignal/review/application/ReviewServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/review/application/ReviewServiceTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
@@ -40,6 +41,7 @@ class ReviewServiceTest {
     private ReviewService reviewService;
 
     @Test
+    @DisplayName("[리뷰를 생성할 수 있다]")
     void postReviewTest() {
         //given
         Long roomId = 2L;
@@ -75,6 +77,8 @@ class ReviewServiceTest {
 
             given(userRepository.findById(i)).willReturn(Optional.of(reviewee));
         }
+        given(reviewRepository.existsReviewByReviewerIdAndRoomId(loginUser.getId(),
+            roomId)).willReturn(false);
 
         //when
         ReviewSaveResponse reviewSaveResponse = reviewService.postReview(reviewSaveRequests,

--- a/core/src/test/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/review/infrastructure/repository/ReviewJpaRepositoryTest.java
@@ -6,6 +6,16 @@ import com.civilwar.boardsignal.common.support.DataJpaTestSupport;
 import com.civilwar.boardsignal.review.ReviewFixture;
 import com.civilwar.boardsignal.review.domain.entity.Review;
 import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import com.civilwar.boardsignal.room.RoomFixture;
+import com.civilwar.boardsignal.room.domain.entity.Participant;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
+import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
+import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.repository.UserRepository;
+import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -18,8 +28,15 @@ class ReviewJpaRepositoryTest extends DataJpaTestSupport {
     Long reviewerId = 1L;
     Long revieweeId = 100L;
     Long roomId = 1L;
+
     @Autowired
     private ReviewJpaRepository reviewJpaRepository;
+    @Autowired
+    private RoomRepository roomRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ParticipantRepository participantRepository;
 
     @Test
     @DisplayName("[사용자가 받은 리뷰 별 평가를 갖고온다]")
@@ -38,5 +55,44 @@ class ReviewJpaRepositoryTest extends DataJpaTestSupport {
         assertThat(reviews.get(0)).isNotNull();
         assertThat(reviews.get(0).getReviewEvaluations()).hasSize(3);
 
+    }
+
+    @Test
+    @DisplayName("[자신이 다른 방에 남긴 각각의 리뷰 2개를 갖고온다]")
+    void findReviewsByRoomIdsAndReviewerTest() throws IOException {
+        //given
+        Room room = RoomFixture.getRoom(Gender.UNION);
+        Room savedRoom = roomRepository.save(room);
+        Room room2 = RoomFixture.getRoom(Gender.UNION);
+        Room savedRoom2 = roomRepository.save(room2);
+
+        User savedLeaderUser = userRepository.save(
+            UserFixture.getUserFixture("providerId", "testURL"));
+        User savedLeaderUser2 = userRepository.save(
+            UserFixture.getUserFixture("providerId", "testURL"));
+        User savedReviewer = userRepository.save(
+            UserFixture.getUserFixture2("providerId", "testURL"));
+
+        participantRepository.save(
+            Participant.of(savedLeaderUser.getId(), savedRoom.getId(), true));
+        participantRepository.save(
+            Participant.of(savedReviewer.getId(), savedRoom2.getId(), false));
+
+        List<ReviewEvaluation> reviewEvaluations = ReviewFixture.getEvaluationFixture();
+        Review review = ReviewFixture.getReviewFixture(savedReviewer.getId(),
+            savedLeaderUser.getId(), savedRoom.getId(), reviewEvaluations);
+        reviewJpaRepository.save(review);
+
+        Review review2 = ReviewFixture.getReviewFixture(savedReviewer.getId(),
+            savedLeaderUser2.getId(), savedRoom2.getId(), reviewEvaluations);
+        reviewJpaRepository.save(review2);
+
+        //when
+        List<Review> reviewsByRoomIdsAndReviewer = reviewJpaRepository
+            .findReviewsByRoomIdsAndReviewer(List.of(savedRoom.getId(), savedRoom2.getId()),
+                savedReviewer.getId());
+
+        //then
+        assertThat(reviewsByRoomIdsAndReviewer).hasSize(2);
     }
 }

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -13,6 +13,10 @@ import com.civilwar.boardsignal.common.MultipartFileFixture;
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import com.civilwar.boardsignal.common.exception.ValidationException;
 import com.civilwar.boardsignal.image.domain.ImageRepository;
+import com.civilwar.boardsignal.review.ReviewFixture;
+import com.civilwar.boardsignal.review.domain.entity.Review;
+import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
+import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
 import com.civilwar.boardsignal.room.MeetingInfoFixture;
 import com.civilwar.boardsignal.room.RoomFixture;
 import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
@@ -81,6 +85,9 @@ class RoomServiceTest {
     @Mock
     private ChatMessageRepository chatMessageRepository;
 
+    @Mock
+    private ReviewRepository reviewRepository;
+
     @InjectMocks
     private RoomService roomService;
 
@@ -134,6 +141,14 @@ class RoomServiceTest {
         }
         given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
+        //0번방, 1번방에 리뷰 남김
+        List<ReviewEvaluation> reviewEvaluations = ReviewFixture.getEvaluationFixture();
+        List<Review> reviews = List.of(
+            ReviewFixture.getReviewFixture(userId, 100L, 0L, reviewEvaluations),
+            ReviewFixture.getReviewFixture(userId, 101L, 0L, reviewEvaluations));
+        given(reviewRepository.findReviewsByRoomIdsAndReviewer(
+            testResult.stream().map(Room::getId).limit(pageRequest.getPageSize()).toList(), userId)).willReturn(reviews);
+
         //when
         RoomPageResponse<GetEndGameResponse> myEndGame = roomService.findMyEndGame(userId,
             pageRequest);
@@ -166,6 +181,14 @@ class RoomServiceTest {
         }
         given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
+        //0번방, 1번방에 리뷰 남김
+        List<ReviewEvaluation> reviewEvaluations = ReviewFixture.getEvaluationFixture();
+        List<Review> reviews = List.of(
+            ReviewFixture.getReviewFixture(userId, 100L, 0L, reviewEvaluations),
+            ReviewFixture.getReviewFixture(userId, 101L, 0L, reviewEvaluations));
+        given(reviewRepository.findReviewsByRoomIdsAndReviewer(
+            List.of(), userId)).willReturn(reviews);
+
         //when
         RoomPageResponse<GetEndGameResponse> myEndGame = roomService.findMyEndGame(userId,
             pageRequest);
@@ -197,6 +220,14 @@ class RoomServiceTest {
         }
         given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
 
+        //0번방, 1번방에 리뷰 남김
+        List<ReviewEvaluation> reviewEvaluations = ReviewFixture.getEvaluationFixture();
+        List<Review> reviews = List.of(
+            ReviewFixture.getReviewFixture(userId, 100L, 0L, reviewEvaluations),
+            ReviewFixture.getReviewFixture(userId, 101L, 0L, reviewEvaluations));
+        given(reviewRepository.findReviewsByRoomIdsAndReviewer(
+            testResult.stream().map(Room::getId).limit(pageRequest.getPageSize()).toList(), userId)).willReturn(reviews);
+
         //when
         RoomPageResponse<GetEndGameResponse> myEndGame = roomService.findMyEndGame(userId,
             pageRequest);
@@ -227,6 +258,14 @@ class RoomServiceTest {
             testResult.add(room);
         }
         given(roomRepository.findMyFixRoom(userId)).willReturn(testResult);
+
+        //0번방, 1번방에 리뷰 남김
+        List<ReviewEvaluation> reviewEvaluations = ReviewFixture.getEvaluationFixture();
+        List<Review> reviews = List.of(
+            ReviewFixture.getReviewFixture(userId, 100L, 0L, reviewEvaluations),
+            ReviewFixture.getReviewFixture(userId, 101L, 0L, reviewEvaluations));
+        given(reviewRepository.findReviewsByRoomIdsAndReviewer(
+            testResult.stream().map(Room::getId).limit(pageRequest.getPageSize()).toList(), userId)).willReturn(reviews);
 
         //when
         RoomPageResponse<GetEndGameResponse> myEndGame = roomService.findMyEndGame(userId,


### PR DESCRIPTION
- #142 

### ⛏ 작업 상세 내용
- 리뷰 등록 시, 해당 모임의 이미 리뷰를 했는지 검증합니다
- 종료된 모임 조회 시, 해당 모임에 리뷰를 완료했는지를 응답 필드에 추가합니다

- 로그인 시, 리다이렉트 URL을 프론트 서버 도메인으로 변경합니다
- 로그인한 사용자 정보 조회 시, 이미지도 함께 반환합니다

### ✅ 중점적으로 리뷰 할 부분

- 추가된 쿼리
- 놓친 요구사항

### 참고사항
