### PR TITLE
feat : 블랙리스트 추가

### DIFF
--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/RoomBlackList.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/RoomBlackList.java
@@ -1,0 +1,49 @@
+package com.civilwar.boardsignal.room.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "ROOM_BLACK_LIST")
+public class RoomBlackList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ROOM_BLACK_LIST_ID")
+    private Long id;
+
+    @Column(name = "ROOM_BLACK_LIST_ROOM_ID")
+    private Long roomId;
+
+    @Column(name = "ROOM_BLACK_LIST_USER_ID")
+    private Long userId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private RoomBlackList(
+        Long roomId,
+        Long userId
+    ) {
+        this.roomId = roomId;
+        this.userId = userId;
+    }
+
+    public static RoomBlackList of(
+        Long roomId,
+        Long userId
+    ) {
+        return RoomBlackList.builder()
+            .roomId(roomId)
+            .userId(userId)
+            .build();
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomBlackListRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomBlackListRepository.java
@@ -1,0 +1,13 @@
+package com.civilwar.boardsignal.room.domain.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.RoomBlackList;
+
+public interface RoomBlackListRepository {
+
+    void save(RoomBlackList blackList);
+
+    void deleteByRoomId(Long roomId);
+
+    boolean existsByUserIdAndRoomId(Long userId, Long roomId);
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/exception/RoomErrorCode.java
@@ -18,7 +18,8 @@ public enum RoomErrorCode implements ErrorCode {
     INVALID_DATE("오늘보다 이전 날짜로 잘못된 날짜입니다.", "R_007"),
     INVALID_HEADCOUNT("인원이 초과되었습니다", "R_008"),
     INVALID_GENDER("성별이 모임의 조건과 일치하지 않습니다", "R_009"),
-    INVALID_AGE("조건에 해당하는 연령만 입장 가능합니다", "R_0010");
+    INVALID_AGE("조건에 해당하는 연령만 입장 가능합니다", "R_0010"),
+    CAN_NOT_PARTICIPANT("추방 당한 방에는 재입장할 수 없습니다", "R_011");
 
 
     private final String message;

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomBlackListRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomBlackListRepositoryAdaptor.java
@@ -1,0 +1,29 @@
+package com.civilwar.boardsignal.room.infrastructure.adaptor;
+
+import com.civilwar.boardsignal.room.domain.entity.RoomBlackList;
+import com.civilwar.boardsignal.room.domain.repository.RoomBlackListRepository;
+import com.civilwar.boardsignal.room.infrastructure.repository.RoomBlackListJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomBlackListRepositoryAdaptor implements RoomBlackListRepository {
+
+    private final RoomBlackListJpaRepository blackListJpaRepository;
+
+    @Override
+    public void save(RoomBlackList blackList) {
+        blackListJpaRepository.save(blackList);
+    }
+
+    @Override
+    public void deleteByRoomId(Long roomId) {
+        blackListJpaRepository.deleteByRoomId(roomId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndRoomId(Long userId, Long roomId) {
+        return blackListJpaRepository.existsByUserIdAndRoomId(userId, roomId);
+    }
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomBlackListJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomBlackListJpaRepository.java
@@ -1,0 +1,13 @@
+package com.civilwar.boardsignal.room.infrastructure.repository;
+
+import com.civilwar.boardsignal.room.domain.entity.RoomBlackList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+public interface RoomBlackListJpaRepository extends JpaRepository<RoomBlackList, Long> {
+
+    @Modifying(clearAutomatically = true)
+    void deleteByRoomId(Long roomId);
+
+    boolean existsByUserIdAndRoomId(Long userId, Long roomId);
+}

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -22,8 +22,10 @@ import com.civilwar.boardsignal.room.RoomFixture;
 import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.domain.entity.RoomBlackList;
 import com.civilwar.boardsignal.room.domain.repository.MeetingInfoRepository;
 import com.civilwar.boardsignal.room.domain.repository.ParticipantRepository;
+import com.civilwar.boardsignal.room.domain.repository.RoomBlackListRepository;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
@@ -69,24 +71,20 @@ class RoomServiceTest {
 
     @Mock
     private RoomRepository roomRepository;
-
     @Mock
     private Supplier<LocalDateTime> time;
-
     @Mock
     private ImageRepository imageRepository;
-
     @Mock
     private ParticipantRepository participantRepository;
-
     @Mock
     private MeetingInfoRepository meetingInfoRepository;
-
     @Mock
     private ChatMessageRepository chatMessageRepository;
-
     @Mock
     private ReviewRepository reviewRepository;
+    @Mock
+    private RoomBlackListRepository blackListRepository;
 
     @InjectMocks
     private RoomService roomService;
@@ -659,6 +657,7 @@ class RoomServiceTest {
         roomService.kickOutUser(leader, kickOutUserRequest);
 
         //then
+        verify(blackListRepository, times(1)).save(any(RoomBlackList.class));
         verify(participantRepository, times(1)).deleteById(userInfoId);
     }
 


### PR DESCRIPTION
- closed #147

### ⛏ 작업 상세 내용

- 블랙리스트 엔티티 설계
- 참가자 추방 시, 블랙리스트 추가
- 모임 삭제 시, 모임과 관련된 블랙리스트 정보 삭제
- 모임 참여 시, 참가자 블랙리스트 확인

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
