### PR TITLE
feat : 프로필 조회 시 signal 업데이트 된 결과 조회

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 
     implementation project(':core')
     testImplementation(testFixtures(project(':core')))
+    implementation project(':scheduler')
 }

--- a/api/src/main/java/com/civilwar/boardsignal/ApiApplication.java
+++ b/api/src/main/java/com/civilwar/boardsignal/ApiApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ApiApplication {
 
     public static void main(String[] args) {
-        System.setProperty("spring.config.name", "application, application-api, application-core");
+        System.setProperty("spring.config.name", "application, application-api, application-core, application-scheduler");
         SpringApplication.run(ApiApplication.class, args);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/common/config/AsyncConfig.java
+++ b/core/src/main/java/com/civilwar/boardsignal/common/config/AsyncConfig.java
@@ -11,16 +11,16 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncConfig {
 
     private final static int CORE_POOL_SIZE = 3;
-    private final static int MAX_POOL_SIZE = 20;
-    private final static int QUEUE_CAPACITY = 100;
+    private final static int MAX_POOL_SIZE = 10;
+    private final static int QUEUE_CAPACITY = 30;
 
-    @Bean(name = "threadPoolTaskExecutor")
+    @Bean(name = "asyncTask")
     public Executor threadPoolTaskExecutor() {
         ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
         taskExecutor.setCorePoolSize(CORE_POOL_SIZE); // 기본 스레드 수
         taskExecutor.setMaxPoolSize(MAX_POOL_SIZE); // 최대 스레드 수
         taskExecutor.setQueueCapacity(QUEUE_CAPACITY); // Queue 사이즈
-        taskExecutor.setThreadNamePrefix("Executor-");
+        taskExecutor.setThreadNamePrefix("async-thread-");
         return taskExecutor;
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -207,16 +207,7 @@ public class RoomService {
     ) {
         boolean hasNext = false;
 
-        //1. 내가 참여한 모든 room
-        List<Room> myFixGame = roomRepository.findMyFixRoom(userId);
-
-        //2. (모임 확정 day) < 현재 day 인 room
-        List<Room> myEndGame = new ArrayList<>(
-            myFixGame.stream()
-                .filter(room -> room.getMeetingInfo().getMeetingTime().toLocalDate()
-                    .isBefore(now.get().toLocalDate())
-                ).toList()
-        );
+        List<Room> myEndGame = getMyEndGames(userId);
 
         //3. Slicing
         List<Room> resultList = new ArrayList<>();
@@ -248,6 +239,19 @@ public class RoomService {
             room -> RoomMapper.toGetEndGameResponse(room, myEndGameReview));
 
         return RoomMapper.toRoomPageResponse(resultMap);
+    }
+
+    public List<Room> getMyEndGames(Long userId) {
+        //1. 내가 참여한 모든 room
+        List<Room> myFixGame = roomRepository.findMyFixRoom(userId);
+
+        //2. (모임 확정 day) < 현재 day 인 room
+        return new ArrayList<>(
+            myFixGame.stream()
+                .filter(room -> room.getMeetingInfo().getMeetingTime().toLocalDate()
+                    .isBefore(now.get().toLocalDate())
+                ).toList()
+        );
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/repository/UserRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/repository/UserRepository.java
@@ -24,4 +24,6 @@ public interface UserRepository {
     Optional<User> findByNicknameAndIsJoined(String nickname, Boolean isJoined);
 
     List<User> findByStation(String station);
+
+    int updateSignal(Long userId, int signal);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/adaptor/UserRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/adaptor/UserRepositoryAdaptor.java
@@ -59,4 +59,9 @@ public class UserRepositoryAdaptor implements UserRepository {
     public List<User> findByStation(String station) {
         return userJpaRepository.findByStation(station);
     }
+
+    @Override
+    public int updateSignal(Long userId, int signal) {
+        return userJpaRepository.updateSignal(userId, signal);
+    }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/repository/UserJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/infrastructure/repository/UserJpaRepository.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.user.domain.entity.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,8 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByNicknameAndIsJoined(String nickname, Boolean isJoined);
 
     List<User> findByStation(String station);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update User u set u.signal = :signal where u.id = :userId")
+    int updateSignal(@Param("userId") Long userId, @Param("signal") int signal);
 }

--- a/core/src/test/java/com/civilwar/boardsignal/user/domain/repository/UserRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/user/domain/repository/UserRepositoryTest.java
@@ -42,4 +42,16 @@ class UserRepositoryTest extends DataJpaTestSupport {
             () -> assertThat(users.get(1).getId()).isEqualTo(user2.getId())
         );
     }
+
+    @Test
+    @DisplayName("[유저의 signal을 업데이트 할 수 있다.]")
+    void updateSignal(){
+        User user = userRepository.findById(1L).orElseThrow();
+        int EndGameSize = 5;
+        userRepository.updateSignal(user.getId(), EndGameSize);
+
+        User findUser = userRepository.findById(1L).orElseThrow();
+
+        assertThat(findUser.getSignal()).isEqualTo(EndGameSize);
+    }
 }

--- a/scheduler/build.gradle
+++ b/scheduler/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation project(':core')
+    testImplementation(testFixtures(project(':core')))
+}

--- a/scheduler/src/main/java/com/civilwar/boardsignal/common/config/SchedulerConfig.java
+++ b/scheduler/src/main/java/com/civilwar/boardsignal/common/config/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.civilwar.boardsignal.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    private final static int POOL_SIZE = 2;
+
+    @Bean("schedulerTask")
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+        executor.setPoolSize(POOL_SIZE);
+        executor.setThreadNamePrefix("scheduler-thread-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/scheduler/src/main/java/com/civilwar/boardsignal/user/scheduler/UserSignalScheduler.java
+++ b/scheduler/src/main/java/com/civilwar/boardsignal/user/scheduler/UserSignalScheduler.java
@@ -1,0 +1,36 @@
+package com.civilwar.boardsignal.user.scheduler;
+
+import com.civilwar.boardsignal.room.application.RoomService;
+import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserSignalScheduler {
+
+    private final UserRepository userRepository;
+    private final RoomService roomService;
+
+    @Async(value = "schedulerTask")
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateSignal(){
+        List<User> users = userRepository.findAll();
+
+        for(User user : users) {
+            List<Room> myEndGames = roomService.getMyEndGames(user.getId());
+            if(user.getSignal() != myEndGames.size()){
+                // 종료된 게임이 늘어난 경우에만 업데이트
+                userRepository.updateSignal(user.getId(), myEndGames.size());
+            }
+            //조회된 EndGame의 size로 업데이트
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'boardsignal'
 include 'core'
 include 'api'
-
+include 'scheduler'


### PR DESCRIPTION
- closed #148 

### ⛏ 작업 상세 내용

- 스케줄러 모듈 추가
- signal 업데이트 쿼리 구현 (더티 체킹 불가하여 직접 쿼리!)
- core모듈, scheduler모듈 Thread Pool 분리
- RoomService EndGame조회 메소드의 끝난 모임 조회 로직 메소드 추출(스케줄러에서 활용)

### ✅ 중점적으로 리뷰 할 부분

- 로직
- 쿼리 테스트 코드

### 참고사항
