### PR TITLE
fix : 방 생성 시, 방장의 lastExit 초기화

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/room/presentation/RoomController.java
@@ -14,6 +14,7 @@ import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetEndGameResponse;
 import com.civilwar.boardsignal.room.dto.response.GetEndGameUsersResponse;
+import com.civilwar.boardsignal.room.dto.response.KickOutResponse;
 import com.civilwar.boardsignal.room.dto.response.ParticipantRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomPageResponse;
@@ -186,11 +187,13 @@ public class RoomController {
     @Operation(summary = "참가자 추방 API (방장용)")
     @ApiResponse(useReturnTypeSchema = true)
     @PostMapping("/kick")
-    public void kickOut(
+    public ResponseEntity<KickOutResponse> kickOut(
         @Parameter(hidden = true)
         @AuthenticationPrincipal User user,
         @RequestBody KickOutUserRequest kickOutUserRequest
     ) {
-        roomFacade.kickOutUser(user, kickOutUserRequest);
+        KickOutResponse kickOutResponse = roomFacade.kickOutUser(user, kickOutUserRequest);
+
+        return ResponseEntity.ok(kickOutResponse);
     }
 }

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -252,9 +252,9 @@ class RoomControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.size").value(5))
             .andExpect(jsonPath("$.hasNext").value(false))
             .andExpect(jsonPath("$.roomsInfos.length()").value(3))
-            .andExpect(jsonPath("$.roomsInfos.[0].id").value(room2.getId()))
+            .andExpect(jsonPath("$.roomsInfos.[0].id").value(room5.getId()))
             .andExpect(jsonPath("$.roomsInfos.[1].id").value(room3.getId()))
-            .andExpect(jsonPath("$.roomsInfos.[2].id").value(room5.getId()));
+            .andExpect(jsonPath("$.roomsInfos.[2].id").value(room2.getId()));
     }
 
     @Test

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -89,8 +89,9 @@ public class RoomService {
             user.getId(),
             savedRoom.getId(),
             true // 방 생성자가 방장여부는 true
-        ); // 나중에 방 폭파 때 해당 방의 Participant 전부 삭제
+        );
         participantRepository.save(participant);
+        participant.updateLastExit(now.get());
 
         return RoomMapper.toCreateRoomResponse(savedRoom);
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Participant.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/entity/Participant.java
@@ -1,5 +1,6 @@
 package com.civilwar.boardsignal.room.domain.entity;
 
+import com.civilwar.boardsignal.common.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Table(name = "PARTICIPANT_TABLE")
-public class Participant {
+public class Participant extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/KickOutFacadeResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/KickOutFacadeResponse.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+import com.civilwar.boardsignal.room.domain.entity.Room;
+
+public record KickOutFacadeResponse(
+    Room room,
+    String kickOutUserNickname
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/KickOutResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/KickOutResponse.java
@@ -1,0 +1,7 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+public record KickOutResponse(
+    String kickOutUserNickname
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/facade/RoomFacade.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/facade/RoomFacade.java
@@ -17,6 +17,8 @@ import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetAllRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.GetEndGameResponse;
 import com.civilwar.boardsignal.room.dto.response.GetEndGameUsersResponse;
+import com.civilwar.boardsignal.room.dto.response.KickOutFacadeResponse;
+import com.civilwar.boardsignal.room.dto.response.KickOutResponse;
 import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import com.civilwar.boardsignal.room.dto.response.ParticipantRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.RoomInfoResponse;
@@ -155,8 +157,11 @@ public class RoomFacade {
         publisher.publishEvent(notificationRequest);
     }
 
-    public void kickOutUser(User leader, KickOutUserRequest kickOutUserRequest) {
-        Room room = roomService.kickOutUser(leader, kickOutUserRequest);
+    public KickOutResponse kickOutUser(User leader, KickOutUserRequest kickOutUserRequest) {
+        KickOutFacadeResponse kickOutFacadeResponse = roomService.kickOutUser(leader, kickOutUserRequest);
+
+        Room room = kickOutFacadeResponse.room();
+        String kickOutUserNickname = kickOutFacadeResponse.kickOutUserNickname();
 
         NotificationRequest notificationRequest = new NotificationRequest(
             NotificationContent.KICKED_FROM_ROOM.getTitle(),
@@ -167,6 +172,8 @@ public class RoomFacade {
         );
 
         publisher.publishEvent(notificationRequest);
+
+        return new KickOutResponse(kickOutUserNickname);
     }
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -22,7 +22,8 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
         + "from Room as r "
         + "join Participant as p "
         + "on r.id = p.roomId "
-        + "where p.userId=:userId ")
+        + "where p.userId=:userId "
+        + "order by p.createdAt desc")
     List<Room> findMyGame(@Param("userId") Long userId);
 
     // 내가 참여한 fix room 조회 쿼리

--- a/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/application/RoomServiceTest.java
@@ -44,6 +44,7 @@ import com.civilwar.boardsignal.user.UserFixture;
 import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
+import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -71,6 +72,8 @@ class RoomServiceTest {
 
     @Mock
     private RoomRepository roomRepository;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private Supplier<LocalDateTime> time;
     @Mock
@@ -650,6 +653,7 @@ class RoomServiceTest {
         given(participantRepository.findByUserIdAndRoomId(userId, roomId)).willReturn(
             Optional.of(userInfo));
         given(roomRepository.findByIdWithLock(roomId)).willReturn(Optional.of(room));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         KickOutUserRequest kickOutUserRequest = new KickOutUserRequest(roomId, userId);
 


### PR DESCRIPTION
- closed #153 

### ⛏ 작업 상세 내용

- 방 생성 시, 방장의 lastExit 초기화
- 채팅 방 목록 정렬 수정
- 참가자 추방 시, 닉네임 내려주기

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
