### PR TITLE
fix : 알림 버그 수정

### DIFF
--- a/api/src/test/java/com/civilwar/boardsignal/notification/presentation/NotificationControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/notification/presentation/NotificationControllerTest.java
@@ -64,11 +64,11 @@ class NotificationControllerTest extends ApiTestSupport {
                 .header(AUTHORIZATION, accessToken))
             .andExpectAll(
                 status().isOk(),
-                jsonPath("$.notificationsInfos[0].notificationId").value(notificationFirst.getId()),
-                jsonPath("$.notificationsInfos[0].roomId").value(notificationFirst.getRoomID()),
+                jsonPath("$.notificationsInfos[0].notificationId").value(notificationSecond.getId()),
+                jsonPath("$.notificationsInfos[0].roomId").value(notificationSecond.getRoomID()),
                 jsonPath("$.notificationsInfos[1].notificationId").value(
-                    notificationSecond.getId()),
-                jsonPath("$.notificationsInfos[1].roomId").value(notificationSecond.getRoomID()),
+                    notificationFirst.getId()),
+                jsonPath("$.notificationsInfos[1].roomId").value(notificationFirst.getRoomID()),
                 jsonPath("$.size").value(10),
                 jsonPath("$.hasNext").value(false)
             );

--- a/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmSender.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmSender.java
@@ -85,37 +85,26 @@ public class FcmSender {
     }
 
     @Async(value = "asyncTask")
-    public void sendMessage(Notification notification) {
-        User user = notification.getUser();
-
-        //해당 user가 사용하는 기기들의 기기 토큰 모두 조회
-        List<String> tokens = user.getUserFcmTokens().stream()
-            .map(UserFcmToken::getToken)
-            .toList();
-
-        for (String token : tokens) {
-            //Request Body 생성
-            HttpEntity<String> requestEntity = null;
-            try {
-                requestEntity = getHttpEntity(
-                    token,
-                    notification.getTitle(),
-                    notification.getBody(),
-                    notification.getImageUrl()
-                );
-            } catch (IOException e) {
-                log.error(e.getMessage());
-            }
-            //Google Api로 알림 전송 요청
-            RestTemplate restTemplate = new RestTemplate();
-            restTemplate.exchange(
-                GOOGLE_API_PREFIX + PROJECT_ID + GOOGLE_API_SUFFIX,
-                POST,
-                requestEntity,
-                String.class
+    public void sendMessage(String token, Notification notification) {
+        HttpEntity<String> requestEntity = null;
+        try {
+            requestEntity = getHttpEntity(
+                token,
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getImageUrl()
             );
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
-
+        //Google Api로 알림 전송 요청
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.exchange(
+            GOOGLE_API_PREFIX + PROJECT_ID + GOOGLE_API_SUFFIX,
+            POST,
+            requestEntity,
+            String.class
+        );
     }
 
     //test용(개발단계에서만 있고 제거 예정)

--- a/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmSender.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/application/FcmSender.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
@@ -83,6 +84,7 @@ public class FcmSender {
         return new HttpEntity<>(requestBody, headers);
     }
 
+    @Async(value = "asyncTask")
     public void sendMessage(Notification notification) {
         User user = notification.getUser();
 

--- a/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/adaptor/NotificationRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/adaptor/NotificationRepositoryAdaptor.java
@@ -33,6 +33,6 @@ public class NotificationRepositoryAdaptor implements NotificationRepository {
 
     @Override
     public Slice<Notification> findAllByUser(User user, Pageable pageable) {
-        return notificationJpaRepository.findAllByUser(user, pageable);
+        return notificationJpaRepository.findAllByUserOrderByCreatedAtDesc(user, pageable);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/repository/NotificationJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/notification/infrastructure/repository/NotificationJpaRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
 
-    Slice<Notification> findAllByUser(User user, Pageable pageable);
+    Slice<Notification> findAllByUserOrderByCreatedAtDesc(User user, Pageable pageable);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/facade/RoomFacade.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/facade/RoomFacade.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -39,6 +40,7 @@ public class RoomFacade {
     private final RoomService roomService;
     private final ApplicationEventPublisher publisher;
 
+    @Transactional
     public CreateRoomResponse createRoom(
         User user,
         CreateRoomRequest request
@@ -102,6 +104,7 @@ public class RoomFacade {
         return roomService.findRoomInfo(user, roomId);
     }
 
+    @Transactional
     public FixRoomResponse fixRoom(
         User user,
         Long roomId,
@@ -135,6 +138,7 @@ public class RoomFacade {
         roomService.unFixRoom(user, roomId);
     }
 
+    @Transactional
     public void deleteRoom(User user, Long roomId) {
         DeleteRoomFacadeResponse response = roomService.deleteRoom(user, roomId);
 
@@ -157,6 +161,7 @@ public class RoomFacade {
         publisher.publishEvent(notificationRequest);
     }
 
+    @Transactional
     public KickOutResponse kickOutUser(User leader, KickOutUserRequest kickOutUserRequest) {
         KickOutFacadeResponse kickOutFacadeResponse = roomService.kickOutUser(leader, kickOutUserRequest);
 


### PR DESCRIPTION
- closed #155 

### ⛏ 작업 상세 내용

- 이벤트 핸들러가 호출한 쪽의 메소드 트랜잭션이 끝나야 실행되기에 퍼사드 클래스 메소드에 트랜잭션 적용(RoomFacade)
- 알림 전송 로직 안에 기기 토큰 꺼내서 반복문 도는 작업 이벤트 핸들러로 이전
    - 하나의 스레드가 외부 api 호출 여러번하는게 부하가 커서 오류 나는 것 같아 비동기로 처리

### ✅ 중점적으로 리뷰 할 부분

### 참고사항

- 계속 프론트와 테스트해보고 잘 되는 거 확인되면 merge할 예정입니다~
- 파일체인지로 리뷰 권장드립니다!~