### PR TITLE
edit : OAuth 로그인 프로세스 변경

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/auth/dto/OAuthUserInfo.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/dto/OAuthUserInfo.java
@@ -2,12 +2,8 @@ package com.civilwar.boardsignal.auth.dto;
 
 public record OAuthUserInfo(
     String email,
-    String name,
     String nickname,
     String imageUrl,
-    String birthYear,
-    String ageRange,
-    String gender,
     String provider,
     String providerId
 ) {

--- a/api/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/mapper/AuthApiMapper.java
@@ -14,12 +14,8 @@ public final class AuthApiMapper {
     public static UserLoginRequest toUserLoginRequest(OAuthUserInfo oAuthUserInfo) {
         return new UserLoginRequest(
             oAuthUserInfo.email(),
-            oAuthUserInfo.name(),
             oAuthUserInfo.nickname(),
             oAuthUserInfo.imageUrl(),
-            oAuthUserInfo.birthYear(),
-            oAuthUserInfo.ageRange(),
-            oAuthUserInfo.gender(),
             oAuthUserInfo.provider(),
             oAuthUserInfo.providerId()
         );

--- a/api/src/main/java/com/civilwar/boardsignal/auth/mapper/OAuthAttributeMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/auth/mapper/OAuthAttributeMapper.java
@@ -30,22 +30,14 @@ public class OAuthAttributeMapper {
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
         String email = (String) kakaoAccount.get("email");
-        String name = (String) kakaoAccount.get("name");
         String nickName = (String) profile.get("nickname");
         String imageUrl = (String) profile.get("profile_image_url");
-        String birthYear = (String) kakaoAccount.get("birthyear");
-        String ageRange = (String) kakaoAccount.get("age_range");
-        String gender = (String) kakaoAccount.get("gender");
         String providerId = userAttributes.get("id").toString();
 
         return new OAuthUserInfo(
             email,
-            name,
             nickName,
             imageUrl,
-            birthYear,
-            ageRange,
-            gender,
             provider,
             providerId
         );
@@ -54,26 +46,18 @@ public class OAuthAttributeMapper {
     private static OAuthUserInfo naverUserInfo(Map<String, Object> userAttributes,
         String provider) {
 
-        Map<String, String> kakaoAccount = (Map<String, String>) userAttributes
+        Map<String, String> naverAccount = (Map<String, String>) userAttributes
             .get("response");
 
-        String email = kakaoAccount.get("email");
-        String name = kakaoAccount.get("name");
-        String nickName = kakaoAccount.get("nickname");
-        String imageUrl = kakaoAccount.get("profile_image");
-        String birthYear = kakaoAccount.get("birthyear");
-        String ageRange = kakaoAccount.get("age");
-        String gender = kakaoAccount.get("gender");
-        String providerId = kakaoAccount.get("id");
+        String email = naverAccount.get("email");
+        String nickName = naverAccount.get("nickname");
+        String imageUrl = naverAccount.get("profile_image");
+        String providerId = naverAccount.get("id");
 
         return new OAuthUserInfo(
             email,
-            name,
             nickName,
             imageUrl,
-            birthYear,
-            ageRange,
-            gender,
             provider,
             providerId
         );

--- a/api/src/main/java/com/civilwar/boardsignal/user/dto/request/ApiUserModifyRequest.java
+++ b/api/src/main/java/com/civilwar/boardsignal/user/dto/request/ApiUserModifyRequest.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 public record ApiUserModifyRequest(
     String nickName,
+    String gender,
+    int birth,
     String line,
     String station,
     List<String> categories

--- a/api/src/main/java/com/civilwar/boardsignal/user/mapper/UserApiMapper.java
+++ b/api/src/main/java/com/civilwar/boardsignal/user/mapper/UserApiMapper.java
@@ -25,6 +25,8 @@ public class UserApiMapper {
             userId,
             apiUserModifyRequest.nickName(),
             userCategories,
+            apiUserModifyRequest.gender(),
+            apiUserModifyRequest.birth(),
             apiUserModifyRequest.line(),
             apiUserModifyRequest.station(),
             image

--- a/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
@@ -1,6 +1,5 @@
 package com.civilwar.boardsignal.auth.presentation;
 
-import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -10,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.auth.exception.AuthErrorCode;
 import com.civilwar.boardsignal.auth.infrastructure.JwtTokenProvider;
-import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.common.support.ApiTestSupport;
 import com.civilwar.boardsignal.user.UserFixture;
 import com.civilwar.boardsignal.user.domain.constants.Role;
@@ -18,13 +16,11 @@ import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("[AuthApiController 테스트]")
 class AuthApiControllerTest extends ApiTestSupport {

--- a/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/auth/presentation/AuthApiControllerTest.java
@@ -96,41 +96,6 @@ class AuthApiControllerTest extends ApiTestSupport {
     }
 
     @Test
-    @Transactional
-    @DisplayName("[AccessToken의 사용자 정보를 반환한다.]")
-    void getLoginUserInfoTest() throws Exception {
-        //given
-        User loginUserEntity = userRepository.findById(loginUser.getId())
-            .orElseThrow();
-
-        String updateNickname = "업데이트된 닉네임";
-        List<Category> categories = List.of(Category.CUSTOMIZABLE, Category.PARTY);
-        String subwayLine = "2호선";
-        String subwayStation = "사당역";
-        String image = "update image";
-        loginUserEntity.updateUser(updateNickname, categories, subwayLine, subwayStation, image);
-
-        LocalDateTime now = LocalDateTime.of(2024, 3, 4, 9, 27, 0);
-        given(nowTime.get()).willReturn(now);
-
-        int expectedAge = nowTime.get().getYear() - loginUser.getBirth() + 1;
-
-        //then
-        mockMvc.perform(get("/api/v1/auth")
-                .header(AUTHORIZATION, accessToken))
-            .andExpect(jsonPath("$.id").value(loginUser.getId()))
-            .andExpect(jsonPath("$.email").value(loginUser.getEmail()))
-            .andExpect(jsonPath("$.nickname").value(updateNickname))
-            .andExpect(jsonPath("$.ageGroup").value(loginUser.getAgeGroup().getDescription()))
-            .andExpect(jsonPath("$.gender").value(loginUser.getGender().getDescription()))
-            .andExpect(jsonPath("$.isJoined").value(true))
-            .andExpect(jsonPath("$.age").value(expectedAge))
-            .andExpect(jsonPath("$.subwayLine").value(subwayLine))
-            .andExpect(jsonPath("$.subwayStation").value(subwayStation))
-            .andExpect(jsonPath("$.categories.size()").value(2));
-    }
-
-    @Test
     @DisplayName("[인증이 안 된 사용자가 접근 시 401 에러와 전용 에러 메시지 & 코드를 반환한다.]")
     void exceptionHandlingTest() throws Exception {
 

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -40,7 +40,6 @@ import com.civilwar.boardsignal.room.dto.request.KickOutUserRequest;
 import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
 import com.civilwar.boardsignal.user.UserFixture;
-import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -781,14 +781,10 @@ class RoomControllerTest extends ApiTestSupport {
         roomRepository.save(room);
 
         User user = User.of("email",
-            "name",
             "nickName",
             "provider",
             "providerId",
-            "testURL",
-            1998,
-            AgeGroup.TWENTY,
-            Gender.MALE);
+            "testURL");
         User savedUser = userRepository.save(user);
 
         Token token = tokenProvider.createToken(savedUser.getId(), Role.USER);
@@ -829,14 +825,10 @@ class RoomControllerTest extends ApiTestSupport {
         roomRepository.save(room);
 
         User user = User.of("email",
-            "name",
             "nickName",
             "provider",
             "providerId",
-            "testURL",
-            2020,
-            AgeGroup.TWENTY,
-            Gender.MALE);
+            "testURL");
         User savedUser = userRepository.save(user);
 
         Token token = tokenProvider.createToken(savedUser.getId(), Role.USER);
@@ -877,14 +869,10 @@ class RoomControllerTest extends ApiTestSupport {
         roomRepository.save(room);
 
         User user = User.of("email",
-            "name",
             "nickName",
             "provider",
             "providerId",
-            "testURL",
-            1998,
-            AgeGroup.TWENTY,
-            Gender.MALE);
+            "testURL");
         User savedUser = userRepository.save(user);
 
         blackListRepository.save(RoomBlackList.of(room.getId(), savedUser.getId()));

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -20,6 +20,8 @@ import com.civilwar.boardsignal.review.domain.entity.Review;
 import com.civilwar.boardsignal.review.domain.entity.ReviewEvaluation;
 import com.civilwar.boardsignal.review.domain.repository.ReviewRepository;
 import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.constants.OAuthProvider;
 import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;
@@ -61,6 +63,8 @@ class UserApiControllerTest extends ApiTestSupport {
 
         ApiUserModifyRequest apiUserModifyRequest = new ApiUserModifyRequest(
             "injuning",
+            Gender.MALE.getDescription(),
+            2000,
             "2호선",
             "사당역",
             List.of("가족게임", "파티게임")
@@ -202,7 +206,7 @@ class UserApiControllerTest extends ApiTestSupport {
     void validNicknameTest2() throws Exception {
         //given
         String existName = loginUser.getName();
-        loginUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), "2호선", "사당역", "testURL");
+        loginUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000, AgeGroup.TWENTY, "2호선", "사당역", "testURL");
         userRepository.save(loginUser);
         ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);
 
@@ -240,7 +244,7 @@ class UserApiControllerTest extends ApiTestSupport {
         User anotherUser = UserFixture.getUserFixture("providerId", "testURL");
         String existName = anotherUser.getName();
         userRepository.save(anotherUser);
-        anotherUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), "2호선", "사당역", "testURL");
+        anotherUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000, AgeGroup.TWENTY, "2호선", "사당역", "testURL");
         userRepository.save(loginUser);
 
         ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -206,7 +206,8 @@ class UserApiControllerTest extends ApiTestSupport {
     void validNicknameTest2() throws Exception {
         //given
         String existName = loginUser.getName();
-        loginUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000, AgeGroup.TWENTY, "2호선", "사당역", "testURL");
+        loginUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000,
+            AgeGroup.TWENTY, "2호선", "사당역", "testURL");
         userRepository.save(loginUser);
         ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);
 
@@ -244,7 +245,8 @@ class UserApiControllerTest extends ApiTestSupport {
         User anotherUser = UserFixture.getUserFixture("providerId", "testURL");
         String existName = anotherUser.getName();
         userRepository.save(anotherUser);
-        anotherUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000, AgeGroup.TWENTY, "2호선", "사당역", "testURL");
+        anotherUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000,
+            AgeGroup.TWENTY, "2호선", "사당역", "testURL");
         userRepository.save(loginUser);
 
         ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);

--- a/core/src/main/java/com/civilwar/boardsignal/auth/application/AuthService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/application/AuthService.java
@@ -7,8 +7,6 @@ import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLoginResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLogoutResponse;
 import com.civilwar.boardsignal.auth.mapper.AuthMapper;
-import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
-import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,14 +31,10 @@ public class AuthService {
             user = userRepository.save(
                 User.of(
                     userLoginRequest.email(),
-                    userLoginRequest.name(),
                     userLoginRequest.nickname(),
                     userLoginRequest.provider(),
                     userLoginRequest.providerId(),
-                    userLoginRequest.imageUrl(),
-                    Integer.parseInt(userLoginRequest.birthYear()),
-                    AgeGroup.of(userLoginRequest.ageRange(), userLoginRequest.provider()),
-                    Gender.of(userLoginRequest.gender(), userLoginRequest.provider())
+                    userLoginRequest.imageUrl()
                 )
             );
         }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/dto/request/UserLoginRequest.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/dto/request/UserLoginRequest.java
@@ -2,12 +2,8 @@ package com.civilwar.boardsignal.auth.dto.request;
 
 public record UserLoginRequest(
     String email,
-    String name,
     String nickname,
     String imageUrl,
-    String birthYear,
-    String ageRange,
-    String gender,
     String provider,
     String providerId
 ) {

--- a/core/src/main/java/com/civilwar/boardsignal/user/application/UserService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/application/UserService.java
@@ -5,6 +5,8 @@ import com.civilwar.boardsignal.boardgame.domain.repository.WishRepository;
 import com.civilwar.boardsignal.common.exception.NotFoundException;
 import com.civilwar.boardsignal.image.domain.ImageRepository;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
+import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.entity.UserCategory;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
@@ -50,6 +52,9 @@ public class UserService {
         findUser.updateUser(
             userModifyRequest.nickName(),
             userModifyRequest.categories(),
+            Gender.toGender(userModifyRequest.gender()),
+            userModifyRequest.birth(),
+            AgeGroup.convert(userModifyRequest.birth(), now.get()),
             userModifyRequest.line(),
             userModifyRequest.station(),
             profileImageUrl

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/AgeGroup.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/AgeGroup.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.user.domain.constants;
 import static com.civilwar.boardsignal.user.exception.UserErrorCode.NOT_FOUND_AGE_GROUP;
 
 import com.civilwar.boardsignal.common.exception.NotFoundException;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,21 +12,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AgeGroup {
 
-    UNDER_CHILDREN("1~9", "1-9", "미취학 아동"),
-    CHILDREN("10~14", "10-14", "어린이"),
-    TEENAGER("14~19", "14-19", "청소년"),
-    TWENTY("20~29", "20-29", "20대"),
-    THIRTY("30~39", "30-39", "30대"),
-    FORTY("40~49", "40-49", "40대"),
-    FIFTY("50~59", "50-59", "50대"),
-    SIXTY("60~69", "60-69", "60대"),
-    SEVENTY("70~79", "70-79", "70대"),
-    EIGHTY("80~89", "80-89", "80대"),
-    NINETY("90~", "90-", "90이상");
+    UNKNOWN("0", "0", "알 ㅅ 없음", 0),
+    UNDER_CHILDREN("1~9", "1-9", "미취학 아동", 9),
+    CHILDREN("10~14", "10-14", "어린이", 14),
+    TEENAGER("14~19", "14-19", "청소년", 19),
+    TWENTY("20~29", "20-29", "20대", 29),
+    THIRTY("30~39", "30-39", "30대", 39),
+    FORTY("40~49", "40-49", "40대",49),
+    FIFTY("50~59", "50-59", "50대", 59),
+    SIXTY("60~69", "60-69", "60대", 69),
+    SEVENTY("70~79", "70-79", "70대", 79),
+    EIGHTY("80~89", "80-89", "80대", 89),
+    NINETY("90~", "90-", "90이상", 100);
 
     private final String kakaoType;
     private final String naverType;
     private final String description;
+    private final int maxAge;
 
     public static AgeGroup of(String input, String provider) {
         return Arrays.stream(values())
@@ -40,5 +43,19 @@ public enum AgeGroup {
         } else {
             return input.equalsIgnoreCase(this.naverType);
         }
+    }
+
+    public static AgeGroup convert(int birthYear, LocalDateTime now) {
+        AgeGroup userAgeGroup = UNKNOWN;
+        int age = now.getYear()-birthYear+1;
+
+        for (AgeGroup a : values()) {
+            //현재 연령대의 사용자의 나이가 포함된다면
+            if (a.getMaxAge()>=age) {
+                userAgeGroup = a;
+            }
+        }
+        return userAgeGroup;
+
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/AgeGroup.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/AgeGroup.java
@@ -18,7 +18,7 @@ public enum AgeGroup {
     TEENAGER("14~19", "14-19", "청소년", 19),
     TWENTY("20~29", "20-29", "20대", 29),
     THIRTY("30~39", "30-39", "30대", 39),
-    FORTY("40~49", "40-49", "40대",49),
+    FORTY("40~49", "40-49", "40대", 49),
     FIFTY("50~59", "50-59", "50대", 59),
     SIXTY("60~69", "60-69", "60대", 69),
     SEVENTY("70~79", "70-79", "70대", 79),
@@ -37,25 +37,25 @@ public enum AgeGroup {
             .orElseThrow(() -> new NotFoundException(NOT_FOUND_AGE_GROUP));
     }
 
+    public static AgeGroup convert(int birthYear, LocalDateTime now) {
+        AgeGroup userAgeGroup = UNKNOWN;
+        int age = now.getYear() - birthYear + 1;
+
+        for (AgeGroup a : values()) {
+            //현재 연령대의 사용자의 나이가 포함된다면
+            if (a.getMaxAge() >= age) {
+                userAgeGroup = a;
+            }
+        }
+        return userAgeGroup;
+
+    }
+
     private boolean isEqual(String input, String provider) {
         if (provider.equals(OAuthProvider.KAKAO.getType())) {
             return input.equalsIgnoreCase(this.kakaoType);
         } else {
             return input.equalsIgnoreCase(this.naverType);
         }
-    }
-
-    public static AgeGroup convert(int birthYear, LocalDateTime now) {
-        AgeGroup userAgeGroup = UNKNOWN;
-        int age = now.getYear()-birthYear+1;
-
-        for (AgeGroup a : values()) {
-            //현재 연령대의 사용자의 나이가 포함된다면
-            if (a.getMaxAge()>=age) {
-                userAgeGroup = a;
-            }
-        }
-        return userAgeGroup;
-
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
@@ -97,7 +97,7 @@ public class User extends BaseEntity implements UserDetails {
     private int signal;
 
     @Builder(access = AccessLevel.PUBLIC)
-    private User(
+    public User(
         @NonNull String email,
         String name,
         @NonNull String nickname,

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
@@ -96,17 +96,17 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "USER_SIGNAL")
     private int signal;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PUBLIC)
     private User(
         @NonNull String email,
-        @NonNull String name,
+        String name,
         @NonNull String nickname,
         @NonNull String provider,
         @NonNull String providerId,
         @NonNull String profileImageUrl,
-        @NonNull int birth,
-        @NonNull AgeGroup ageGroup,
-        @NonNull Gender gender
+        int birth,
+        AgeGroup ageGroup,
+        Gender gender
     ) {
         this.email = email;
         this.name = name;
@@ -125,25 +125,17 @@ public class User extends BaseEntity implements UserDetails {
 
     public static User of(
         String email,
-        String name,
         String nickname,
         String provider,
         String providerId,
-        String profileImageUrl,
-        int birth,
-        AgeGroup ageGroup,
-        Gender gender
+        String profileImageUrl
     ) {
         return User.builder()
             .email(email)
-            .name(name)
             .nickname(nickname)
             .provider(provider)
             .providerId(providerId)
             .profileImageUrl(profileImageUrl)
-            .birth(birth)
-            .ageGroup(ageGroup)
-            .gender(gender)
             .build();
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
@@ -142,11 +142,17 @@ public class User extends BaseEntity implements UserDetails {
     public void updateUser(
         String nickname,
         List<Category> categories,
+        Gender gender,
+        int birth,
+        AgeGroup ageGroup,
         String line,
         String station,
         String profileImageUrl
     ) {
         this.nickname = nickname;
+        this.gender = gender;
+        this.birth = birth;
+        this.ageGroup = ageGroup;
         this.line = line;
         this.station = station;
         this.userCategories.clear();

--- a/core/src/main/java/com/civilwar/boardsignal/user/dto/request/UserModifyRequest.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/dto/request/UserModifyRequest.java
@@ -9,6 +9,8 @@ public record UserModifyRequest(
     Long id,
     String nickName,
     List<Category> categories,
+    String gender,
+    int birth,
     String line,
     String station,
     MultipartFile image

--- a/core/src/test/java/com/civilwar/boardsignal/auth/application/AuthServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/auth/application/AuthServiceTest.java
@@ -12,8 +12,6 @@ import com.civilwar.boardsignal.auth.dto.request.UserLoginRequest;
 import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLoginResponse;
 import com.civilwar.boardsignal.user.UserFixture;
-import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
-import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.constants.OAuthProvider;
 import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;

--- a/core/src/test/java/com/civilwar/boardsignal/auth/application/AuthServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/auth/application/AuthServiceTest.java
@@ -48,11 +48,7 @@ class AuthServiceTest {
         UserLoginRequest userLoginRequest = new UserLoginRequest(
             "abc1234@gmail.com",
             "최인준",
-            "injuning",
             "testURL",
-            String.valueOf(2000),
-            AgeGroup.TWENTY.getKakaoType(),
-            Gender.MALE.getKakaoType(),
             OAuthProvider.KAKAO.getType(),
             providerId
         );
@@ -84,10 +80,6 @@ class AuthServiceTest {
             "abc1234@gmail.com",
             "최인준",
             "injuning",
-            "testURL",
-            String.valueOf(2000),
-            AgeGroup.TWENTY.getKakaoType(),
-            Gender.MALE.getKakaoType(),
             OAuthProvider.KAKAO.getType(),
             providerId
         );

--- a/core/src/test/java/com/civilwar/boardsignal/user/application/UserServiceTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/user/application/UserServiceTest.java
@@ -7,13 +7,16 @@ import com.civilwar.boardsignal.boardgame.domain.constant.Category;
 import com.civilwar.boardsignal.common.MultipartFileFixture;
 import com.civilwar.boardsignal.image.domain.ImageRepository;
 import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import com.civilwar.boardsignal.user.dto.request.UserModifyRequest;
 import com.civilwar.boardsignal.user.dto.response.UserModifyResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +34,8 @@ class UserServiceTest {
     private UserRepository userRepository;
     @Mock
     private ImageRepository imageRepository;
+    @Mock
+    private Supplier<LocalDateTime> now;
     @InjectMocks
     private UserService userService;
 
@@ -48,6 +53,8 @@ class UserServiceTest {
             id,
             "injuning",
             List.of(Category.FAMILY, Category.PARTY),
+            Gender.MALE.getDescription(),
+            2000,
             "2호선",
             "사당역",
             imageFixture
@@ -55,6 +62,7 @@ class UserServiceTest {
         User userFixture = UserFixture.getUserFixture(providerId, testUrl);
         Boolean isJoined = userFixture.getIsJoined();
 
+        when(now.get()).thenReturn(LocalDateTime.of(2024,11,20,0,0,0));
         when(imageRepository.save(imageFixture)).thenReturn(testUrl);
         when(userRepository.findById(id)).thenReturn(Optional.of(userFixture));
         ReflectionTestUtils.setField(userFixture, "id", id);

--- a/core/src/testFixtures/java/com/civilwar/boardsignal/user/UserFixture.java
+++ b/core/src/testFixtures/java/com/civilwar/boardsignal/user/UserFixture.java
@@ -14,7 +14,7 @@ public class UserFixture {
     public static User getUserFixture(String providerId, String imageUrl) {
 
         String provider = OAuthProvider.KAKAO.getType();
-        return User.of(
+        return new User(
             "abc1234@gmail.com",
             "최인준",
             "injuning",
@@ -30,7 +30,7 @@ public class UserFixture {
     public static User getUserFixture2(String providerId, String imageUrl) {
 
         String provider = OAuthProvider.KAKAO.getType();
-        return User.of(
+        return new User(
             "abc12345678@naver.com",
             "김강훈",
             "macbook",


### PR DESCRIPTION
- closed #168 

### ⛏ 작업 상세 내용
- OAuth 로그인 시, 이메일, 닉네임, 프로필 이미지만 갖고옵니다.
- 회원가입 폼에서 성별과 출생년도를 받아옵니다
- OAuth 로그인을 테스트 어플리케이션이 아닌 정상 어플리케이션으로 변경합니다

### ✅ 중점적으로 리뷰 할 부분
- User 엔티티 변경으로 TestFixture 수정이 너무 많아, User 생성자를 public 으로 수정하였습니다..!

### 참고사항
- yml파일 변경 후, 서버에 올려서 직접 테스트 해보아야 합니다..!! 따라서 수정 사항이 더 있을 수 있습니다!