### PR TITLE
edit : 채팅 방 조회 기능 리팩토링

### DIFF
--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.civilwar.boardsignal.auth.domain.TokenProvider;
 import com.civilwar.boardsignal.auth.domain.model.Token;
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.chat.domain.constant.MessageType;
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
 import com.civilwar.boardsignal.chat.domain.repository.ChatMessageRepository;
 import com.civilwar.boardsignal.common.exception.NotFoundException;
@@ -44,7 +45,9 @@ import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
+import jakarta.validation.constraints.Null;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -254,6 +257,55 @@ class RoomControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.roomsInfos.[0].id").value(room5.getId()))
             .andExpect(jsonPath("$.roomsInfos.[1].id").value(room3.getId()))
             .andExpect(jsonPath("$.roomsInfos.[2].id").value(room2.getId()));
+    }
+
+    @Test
+    @DisplayName("사용자는 자신이 참여중인 채팅방을 조회할 때, 채팅방 별 읽지 않은 메시지 갯수와 마지막 메시지를 함께 반환한다.")
+    void getMyChattingRoomTest2() throws Exception {
+        //given
+        LocalDateTime now = LocalDateTime.of(2024, 2, 21, 20, 0, 0);
+        given(nowTime.get()).willReturn(now);
+
+        //읽지 않은 채팅이 없는 방
+        Room room1 = RoomFixture.getRoom(Gender.UNION);
+        roomRepository.save(room1);
+        //읽지 않은 채팅이 있는 방
+        Room room2 = RoomFixture.getRoom(Gender.UNION);
+        roomRepository.save(room2);
+
+        //참가
+        Participant participant = Participant.of(loginUser.getId(), room1.getId(), true);
+        participant.updateLastExit(nowTime.get());
+        participantRepository.save(participant);
+        Participant participant2 = Participant.of(loginUser.getId(), room2.getId(), true);
+        participant2.updateLastExit(nowTime.get());
+        participantRepository.save(participant2);
+
+        //채팅 추가
+        //1번방 채팅 추가 x
+        //2번방 채팅 추가
+        for (int i = 0; i < 3; i++) {
+            ChatMessage chatMessage = ChatMessage.of(room2.getId(), 100L, "테스트 " + i, MessageType.CHAT);
+            chatMessageRepository.save(chatMessage);
+        }
+
+        //then
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", "0");
+        params.add("size", "5");
+        mockMvc.perform(get("/api/v1/rooms/my/games")
+                .header(AUTHORIZATION, accessToken)
+                .params(params))
+            .andExpect(jsonPath("$.currentPageNumber").value(0))
+            .andExpect(jsonPath("$.size").value(5))
+            .andExpect(jsonPath("$.hasNext").value(false))
+            .andExpect(jsonPath("$.roomsInfos.length()").value(2))
+            .andExpect(jsonPath("$.roomsInfos.[0].id").value(room2.getId()))
+            .andExpect(jsonPath("$.roomsInfos.[0].unreadChatCount").value(3))
+            .andExpect(jsonPath("$.roomsInfos.[0].lastChatMessage").value("테스트 2"))
+            .andExpect(jsonPath("$.roomsInfos.[1].id").value(room1.getId()))
+            .andExpect(jsonPath("$.roomsInfos.[1].unreadChatCount").value(0))
+            .andExpect(jsonPath("$.roomsInfos.[1].lastChatMessage").doesNotExist());
     }
 
     @Test

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -45,9 +45,7 @@ import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
-import jakarta.validation.constraints.Null;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -285,7 +283,8 @@ class RoomControllerTest extends ApiTestSupport {
         //1번방 채팅 추가 x
         //2번방 채팅 추가
         for (int i = 0; i < 3; i++) {
-            ChatMessage chatMessage = ChatMessage.of(room2.getId(), 100L, "테스트 " + i, MessageType.CHAT);
+            ChatMessage chatMessage = ChatMessage.of(room2.getId(), 100L, "테스트 " + i,
+                MessageType.CHAT);
             chatMessageRepository.save(chatMessage);
         }
 

--- a/core/src/main/java/com/civilwar/boardsignal/chat/domain/repository/ChatMessageRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/domain/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.civilwar.boardsignal.chat.domain.repository;
 
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
+import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -15,4 +16,6 @@ public interface ChatMessageRepository {
     Slice<ChatMessageDto> findChatAllByRoomId(Long roomId, Pageable pageable);
 
     void deleteByRoomId(Long roomId);
+
+    List<ChatCountDto> countsByRoomIds(Long userId, List<Long> roomIds);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/domain/repository/ChatMessageRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/domain/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.chat.domain.repository;
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
 import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
+import com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -18,4 +19,6 @@ public interface ChatMessageRepository {
     void deleteByRoomId(Long roomId);
 
     List<ChatCountDto> countsByRoomIds(Long userId, List<Long> roomIds);
+
+    List<LastChatMessageDto> findLastChatMessage(List<Long> roomIds);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/ChatCountDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/ChatCountDto.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.chat.dto.response;
+
+public record ChatCountDto(
+    Long roomId,
+    Long uncheckedMessage
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/LastChatMessageDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/LastChatMessageDto.java
@@ -1,0 +1,8 @@
+package com.civilwar.boardsignal.chat.dto.response;
+
+public record LastChatMessageDto(
+    Long roomId,
+    String content
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/adaptor/ChatMessageRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/adaptor/ChatMessageRepositoryAdaptor.java
@@ -4,6 +4,7 @@ import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
 import com.civilwar.boardsignal.chat.domain.repository.ChatMessageRepository;
 import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
+import com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto;
 import com.civilwar.boardsignal.chat.infrastructure.repository.ChatMessageJpaRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +41,10 @@ public class ChatMessageRepositoryAdaptor implements ChatMessageRepository {
     @Override
     public List<ChatCountDto> countsByRoomIds(Long userId, List<Long> roomIds) {
         return chatMessageJpaRepository.countsByRoomIds(userId, roomIds);
+    }
+
+    @Override
+    public List<LastChatMessageDto> findLastChatMessage(List<Long> roomIds) {
+        return chatMessageJpaRepository.findLastChatMessage(roomIds);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/adaptor/ChatMessageRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/adaptor/ChatMessageRepositoryAdaptor.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.chat.infrastructure.adaptor;
 
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
 import com.civilwar.boardsignal.chat.domain.repository.ChatMessageRepository;
+import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
 import com.civilwar.boardsignal.chat.infrastructure.repository.ChatMessageJpaRepository;
 import java.util.List;
@@ -34,5 +35,10 @@ public class ChatMessageRepositoryAdaptor implements ChatMessageRepository {
     @Override
     public void deleteByRoomId(Long roomId) {
         chatMessageJpaRepository.deleteChatMessagesByRoomId(roomId);
+    }
+
+    @Override
+    public List<ChatCountDto> countsByRoomIds(Long userId, List<Long> roomIds) {
+        return chatMessageJpaRepository.countsByRoomIds(userId, roomIds);
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
@@ -1,6 +1,7 @@
 package com.civilwar.boardsignal.chat.infrastructure.repository;
 
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
+import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -23,8 +24,18 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessage, Lon
             + "order by c.createdAt desc ")
     Slice<ChatMessageDto> findChatAllByRoomId(@Param("roomId") Long roomId, Pageable pageable);
 
-
     @Modifying(clearAutomatically = true)
     void deleteChatMessagesByRoomId(Long roomId);
 
+    //채팅 메시지 생성시간이 참여자 채팅방 확인 시간 이후인 메시지 갯수 (Participant.lastExit < ChatMessage.createdAt)
+    @Query("select new com.civilwar.boardsignal.chat.dto.response.ChatCountDto(c.roomId, count(c)) "
+        + "from ChatMessage as c "
+        + "join Participant as p "
+        + "on p.roomId = c.roomId "
+        + "where p.userId = :userId "
+        + "and c.roomId in :roomIds "
+        + "and c.createdAt>p.lastExit "
+        + "group by c.roomId")
+    List<ChatCountDto> countsByRoomIds(@Param("userId") Long userId,
+        @Param("roomIds") List<Long> roomIds);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
@@ -41,7 +41,8 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessage, Lon
         @Param("roomIds") List<Long> roomIds);
 
     //채팅방 별 마지막 메시지 조회
-    @Query("select new com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto(c.roomId, c.content) "
+    @Query(
+        "select new com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto(c.roomId, c.content) "
             + "from ChatMessage as c "
             + "where c.roomId in :roomIds "
             + "and c.createdAt in (select max(c.createdAt) from ChatMessage as c group by c.roomId) ")

--- a/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
@@ -3,6 +3,7 @@ package com.civilwar.boardsignal.chat.infrastructure.repository;
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
 import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
 import com.civilwar.boardsignal.chat.dto.response.ChatMessageDto;
+import com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -38,4 +39,11 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessage, Lon
         + "group by c.roomId")
     List<ChatCountDto> countsByRoomIds(@Param("userId") Long userId,
         @Param("roomIds") List<Long> roomIds);
+
+    //채팅방 별 마지막 메시지 조회
+    @Query("select new com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto(c.roomId, c.content) "
+            + "from ChatMessage as c "
+            + "where c.roomId in :roomIds "
+            + "and c.createdAt in (select max(c.createdAt) from ChatMessage as c group by c.roomId) ")
+    List<LastChatMessageDto> findLastChatMessage(@Param("roomIds") List<Long> roomIds);
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -27,6 +27,7 @@ import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.FixRoomRequest;
 import com.civilwar.boardsignal.room.dto.request.KickOutUserRequest;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomDto;
 import com.civilwar.boardsignal.room.dto.response.ChatRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.DeleteRoomFacadeResponse;
@@ -177,14 +178,14 @@ public class RoomService {
             .withNano(0);
 
         //1. 내가 참여한 채팅방
-        Slice<Room> myChattingRoom = roomRepository.findMyChattingRoom(user.getId(), today,
+        Slice<ChatRoomDto> myChattingRoom = roomRepository.findMyChattingRoom(user.getId(), today,
             pageable);
 
         //2. 채팅방 별 내가 읽지 않은 메시지 갯수
         //1) 내가 참여한 채팅방 id 리스트
         List<Long> roomIdList = myChattingRoom.getContent()
             .stream()
-            .map(Room::getId)
+            .map(ChatRoomDto::id)
             .toList();
 
         //2) 채팅방 별 내가 읽지 않은 채팅 메시지 갯수 조회

--- a/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/application/RoomService.java
@@ -197,7 +197,8 @@ public class RoomService {
             roomIdList);
 
         //매핑
-        Slice<ChatRoomResponse> myChattingRoomResult = myChattingRoom.map(room -> RoomMapper.toChatRoomResponse(room, unreadChatCounts, lastChatMessages));
+        Slice<ChatRoomResponse> myChattingRoomResult = myChattingRoom.map(
+            room -> RoomMapper.toChatRoomResponse(room, unreadChatCounts, lastChatMessages));
 
         return RoomMapper.toRoomPageResponse(myChattingRoomResult);
     }

--- a/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/domain/repository/RoomRepository.java
@@ -2,6 +2,7 @@ package com.civilwar.boardsignal.room.domain.repository;
 
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomDto;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
@@ -16,7 +17,7 @@ public interface RoomRepository {
 
     Optional<Room> findById(Long id);
 
-    Slice<Room> findMyChattingRoom(Long userId, LocalDateTime today, Pageable pageable);
+    Slice<ChatRoomDto> findMyChattingRoom(Long userId, LocalDateTime today, Pageable pageable);
 
     Slice<Room> findMyEndRoomPaging(Long userId, LocalDateTime today, Pageable pageable);
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -1,6 +1,8 @@
 package com.civilwar.boardsignal.room.dto.mapper;
 
 import com.civilwar.boardsignal.boardgame.domain.constant.Category;
+import com.civilwar.boardsignal.chat.dto.response.ChatCountDto;
+import com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto;
 import com.civilwar.boardsignal.review.domain.entity.Review;
 import com.civilwar.boardsignal.room.domain.constants.DaySlot;
 import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
@@ -223,11 +225,32 @@ public final class RoomMapper {
         );
     }
 
-    public static ChatRoomResponse toChatRoomResponse(Room room) {
+    public static ChatRoomResponse toChatRoomResponse(
+        Room room,
+        List<ChatCountDto> unreadChatCounts,
+        List<LastChatMessageDto> lastChatMessages
+    ) {
+        Long unreadChatCount = unreadChatCounts
+            .stream()
+            .filter(chatCountDto -> chatCountDto.roomId().equals(room.getId()))
+            .findFirst()
+            .map(ChatCountDto::uncheckedMessage)
+            .orElse(0L);
+
+        String lastChatMessage = lastChatMessages
+            .stream()
+            .filter(lastChatMessageDto -> lastChatMessageDto.roomId().equals(room.getId()))
+            .findFirst()
+            .map(LastChatMessageDto::content)
+            .orElse(null);
+
         return new ChatRoomResponse(
             room.getId(),
             room.getTitle(),
             room.getImageUrl(),
-            room.getHeadCount());
+            room.getHeadCount(),
+            Integer.parseInt(String.valueOf(unreadChatCount)),
+            lastChatMessage
+            );
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -252,6 +252,6 @@ public final class RoomMapper {
             room.headCount(),
             Integer.parseInt(String.valueOf(unreadChatCount)),
             lastChatMessage
-            );
+        );
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -9,6 +9,7 @@ import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import com.civilwar.boardsignal.room.domain.entity.MeetingInfo;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.dto.request.CreateRoomRequest;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomDto;
 import com.civilwar.boardsignal.room.dto.response.ChatRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.CreateRoomResponse;
 import com.civilwar.boardsignal.room.dto.response.FixRoomResponse;
@@ -226,29 +227,29 @@ public final class RoomMapper {
     }
 
     public static ChatRoomResponse toChatRoomResponse(
-        Room room,
+        ChatRoomDto room,
         List<ChatCountDto> unreadChatCounts,
         List<LastChatMessageDto> lastChatMessages
     ) {
         Long unreadChatCount = unreadChatCounts
             .stream()
-            .filter(chatCountDto -> chatCountDto.roomId().equals(room.getId()))
+            .filter(chatCountDto -> chatCountDto.roomId().equals(room.id()))
             .findFirst()
             .map(ChatCountDto::uncheckedMessage)
             .orElse(0L);
 
         String lastChatMessage = lastChatMessages
             .stream()
-            .filter(lastChatMessageDto -> lastChatMessageDto.roomId().equals(room.getId()))
+            .filter(lastChatMessageDto -> lastChatMessageDto.roomId().equals(room.id()))
             .findFirst()
             .map(LastChatMessageDto::content)
             .orElse(null);
 
         return new ChatRoomResponse(
-            room.getId(),
-            room.getTitle(),
-            room.getImageUrl(),
-            room.getHeadCount(),
+            room.id(),
+            room.title(),
+            room.imageUrl(),
+            room.headCount(),
             Integer.parseInt(String.valueOf(unreadChatCount)),
             lastChatMessage
             );

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomDto.java
@@ -1,0 +1,10 @@
+package com.civilwar.boardsignal.room.dto.response;
+
+public record ChatRoomDto(
+    Long id,
+    String title,
+    String imageUrl,
+    int headCount
+) {
+
+}

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomResponse.java
@@ -4,7 +4,9 @@ public record ChatRoomResponse(
     Long id,
     String title,
     String imageUrl,
-    int headCount
+    int headCount,
+    int unreadChatCount,
+    String lastChatMessage
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -111,7 +111,8 @@ public class RoomRepositoryAdaptor implements RoomRepository {
     }
 
     @Override
-    public Slice<ChatRoomDto> findMyChattingRoom(Long userId, LocalDateTime today, Pageable pageable) {
+    public Slice<ChatRoomDto> findMyChattingRoom(Long userId, LocalDateTime today,
+        Pageable pageable) {
         return roomJpaRepository.findMyChattingRoom(userId, today, pageable);
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/adaptor/RoomRepositoryAdaptor.java
@@ -11,6 +11,7 @@ import com.civilwar.boardsignal.room.domain.constants.TimeSlot;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomDto;
 import com.civilwar.boardsignal.room.infrastructure.repository.RoomJpaRepository;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -110,7 +111,7 @@ public class RoomRepositoryAdaptor implements RoomRepository {
     }
 
     @Override
-    public Slice<Room> findMyChattingRoom(Long userId, LocalDateTime today, Pageable pageable) {
+    public Slice<ChatRoomDto> findMyChattingRoom(Long userId, LocalDateTime today, Pageable pageable) {
         return roomJpaRepository.findMyChattingRoom(userId, today, pageable);
     }
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -21,15 +21,16 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
 
     // 내가 현재 참여한 채팅방 조회
     // 미확정 모임 또는 모임 시간이 (오늘~미래)인 모임
-    @Query("select new com.civilwar.boardsignal.room.dto.response.ChatRoomDto(r.id, r.title, r.imageUrl, r.headCount)"
-        + "from Room as r "
-        + "left join MeetingInfo as m "
-        + "on m.id = r.meetingInfo.id "
-        + "join Participant as p "
-        + "on r.id = p.roomId "
-        + "where p.userId=:userId "
-        + "and (m.meetingTime>=:today or m.meetingTime is null) "
-        + "order by p.createdAt desc")
+    @Query(
+        "select new com.civilwar.boardsignal.room.dto.response.ChatRoomDto(r.id, r.title, r.imageUrl, r.headCount)"
+            + "from Room as r "
+            + "left join MeetingInfo as m "
+            + "on m.id = r.meetingInfo.id "
+            + "join Participant as p "
+            + "on r.id = p.roomId "
+            + "where p.userId=:userId "
+            + "and (m.meetingTime>=:today or m.meetingTime is null) "
+            + "order by p.createdAt desc")
     Slice<ChatRoomDto> findMyChattingRoom(@Param("userId") Long userId,
         @Param("today") LocalDateTime today, Pageable pageable);
 

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -1,6 +1,7 @@
 package com.civilwar.boardsignal.room.infrastructure.repository;
 
 import com.civilwar.boardsignal.room.domain.entity.Room;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomDto;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -20,7 +21,7 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
 
     // 내가 현재 참여한 채팅방 조회
     // 미확정 모임 또는 모임 시간이 (오늘~미래)인 모임
-    @Query("select r "
+    @Query("select new com.civilwar.boardsignal.room.dto.response.ChatRoomDto(r.id, r.title, r.imageUrl, r.headCount)"
         + "from Room as r "
         + "left join MeetingInfo as m "
         + "on m.id = r.meetingInfo.id "
@@ -29,7 +30,7 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
         + "where p.userId=:userId "
         + "and (m.meetingTime>=:today or m.meetingTime is null) "
         + "order by p.createdAt desc")
-    Slice<Room> findMyChattingRoom(@Param("userId") Long userId,
+    Slice<ChatRoomDto> findMyChattingRoom(@Param("userId") Long userId,
         @Param("today") LocalDateTime today, Pageable pageable);
 
     // 내가 어제까지 참여한 종료된 모임 (페이징 버전)

--- a/core/src/test/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.civilwar.boardsignal.chat.infrastructure.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
 
 import com.civilwar.boardsignal.chat.domain.constant.MessageType;
 import com.civilwar.boardsignal.chat.domain.entity.ChatMessage;
@@ -26,7 +26,6 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
@@ -193,7 +192,8 @@ class ChatMessageJpaRepositoryTest extends DataJpaTestSupport {
             chatMessageRepository.save(chatMessage);
         }
 
-        List<LastChatMessageDto> lastChatMessages = chatMessageRepository.findLastChatMessage(List.of(room2.getId(),
+        List<LastChatMessageDto> lastChatMessages = chatMessageRepository.findLastChatMessage(
+            List.of(room2.getId(),
                 room3.getId()));
 
         assertThat(lastChatMessages).hasSize(2);

--- a/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
@@ -13,6 +13,7 @@ import com.civilwar.boardsignal.room.domain.entity.Participant;
 import com.civilwar.boardsignal.room.domain.entity.Room;
 import com.civilwar.boardsignal.room.domain.repository.RoomRepository;
 import com.civilwar.boardsignal.room.dto.request.RoomSearchCondition;
+import com.civilwar.boardsignal.room.dto.response.ChatRoomDto;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -95,15 +96,15 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
         LocalDateTime today = LocalDateTime.of(2024, 4, 11, 0, 0, 0);
         PageRequest pageable = PageRequest.of(0, 5);
 
-        Slice<Room> myChattingRoom = roomRepository.findMyChattingRoom(user, today, pageable);
-        List<Room> content = myChattingRoom.getContent();
+        Slice<ChatRoomDto> myChattingRoom = roomRepository.findMyChattingRoom(user, today, pageable);
+        List<ChatRoomDto> content = myChattingRoom.getContent();
 
         //then
         assertThat(content).hasSize(3);
         //최신 참여 순 정렬
-        assertThat(content.get(0).getId()).isEqualTo(futureRoom.getId());
-        assertThat(content.get(1).getId()).isEqualTo(todayRoom.getId());
-        assertThat(content.get(2).getId()).isEqualTo(nonFixRoom.getId());
+        assertThat(content.get(0).id()).isEqualTo(futureRoom.getId());
+        assertThat(content.get(1).id()).isEqualTo(todayRoom.getId());
+        assertThat(content.get(2).id()).isEqualTo(nonFixRoom.getId());
     }
 
     @Test

--- a/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
+++ b/core/src/test/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepositoryTest.java
@@ -96,7 +96,8 @@ class RoomJpaRepositoryTest extends DataJpaTestSupport {
         LocalDateTime today = LocalDateTime.of(2024, 4, 11, 0, 0, 0);
         PageRequest pageable = PageRequest.of(0, 5);
 
-        Slice<ChatRoomDto> myChattingRoom = roomRepository.findMyChattingRoom(user, today, pageable);
+        Slice<ChatRoomDto> myChattingRoom = roomRepository.findMyChattingRoom(user, today,
+            pageable);
         List<ChatRoomDto> content = myChattingRoom.getContent();
 
         //then


### PR DESCRIPTION
- closed #171 

### ⛏ 작업 상세 내용

1. 채팅방 목록 조회 시 응답 필드 추가

기존
- 모임 정보

변경
- 모임 정보
- 채팅방 별 읽지 않은 메시지 갯수
- 마지막으로 받은 채팅 함께 응답
(카카오톡 채팅방 목록에서 마지막 메시지 보여주는 거 생각하시면 됩니다) 
![image](https://github.com/BoardSignal/Team-CivilWar-BoardSignal-BE/assets/102799700/c58cbde4-3056-453b-a647-acee5df3aa28)



2. 채팅방 목록 조회 시, 필요한 데이터만 갖고오도록 쿼리 수정
- 쿼리를 좀 더 핏하게 갖고오도록 하엿습니다

### ✅ 중점적으로 리뷰 할 부분

1. 효율적인 쿼리
채팅방 목록 조회 기능에서 다음과 같이 쿼리가 3방이 나갑니다
- 채팅방 목록 조회
- 채팅방 별 읽지 않은 메시지 갯수 조회
- 채팅방 별 마지막 채팅 조회

**이 쿼리 3개를 통합해서 줄이고 싶었는데, 방법이 없는 것 같아 여쭙고 싶습니다..!**

2. 만약 위의 사항의 개선사항이 뚜렷하지 않다면, 추가된 쿼리와 테스트 케이스를 봐주시면 감사합니다

### 참고사항
- 커밋 별로 보시면 됩니다!