### PR TITLE
hotfix : OAuth 첫 로그인 시 버그 수정

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
@@ -66,10 +66,10 @@ public class UserApiController {
 
     @Operation(summary = "닉네임 중복 체크 API")
     @ApiResponse(useReturnTypeSchema = true)
-    @PostMapping("/valid")
+    @GetMapping("/valid")
     public ResponseEntity<ValidNicknameResponse> validNickname(
         @Parameter(hidden = true) @AuthenticationPrincipal User loginUser,
-        @RequestBody ValidNicknameRequest validNicknameRequest
+        ValidNicknameRequest validNicknameRequest
     ) {
         ValidNicknameResponse response = userService.isExistNickname(validNicknameRequest,
             loginUser);

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -41,6 +41,7 @@ import com.civilwar.boardsignal.room.dto.request.KickOutUserRequest;
 import com.civilwar.boardsignal.room.dto.response.ParticipantJpaDto;
 import com.civilwar.boardsignal.room.infrastructure.repository.MeetingInfoJpaRepository;
 import com.civilwar.boardsignal.user.UserFixture;
+import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
 import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;
@@ -834,7 +835,9 @@ class RoomControllerTest extends ApiTestSupport {
             "nickName",
             "provider",
             "providerId",
-            "testURL");
+            "testURL",
+            Gender.MALE,
+            AgeGroup.TWENTY);
         User savedUser = userRepository.save(user);
 
         Token token = tokenProvider.createToken(savedUser.getId(), Role.USER);
@@ -878,7 +881,10 @@ class RoomControllerTest extends ApiTestSupport {
             "nickName",
             "provider",
             "providerId",
-            "testURL");
+            "testURL",
+            Gender.MALE,
+            AgeGroup.THIRTY
+        );
         User savedUser = userRepository.save(user);
 
         Token token = tokenProvider.createToken(savedUser.getId(), Role.USER);
@@ -922,7 +928,10 @@ class RoomControllerTest extends ApiTestSupport {
             "nickName",
             "provider",
             "providerId",
-            "testURL");
+            "testURL",
+            Gender.MALE,
+            AgeGroup.TWENTY
+        );
         User savedUser = userRepository.save(user);
 
         blackListRepository.save(RoomBlackList.of(room.getId(), savedUser.getId()));

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -41,6 +41,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 @DisplayName("[UserController 테스트]")
 class UserApiControllerTest extends ApiTestSupport {
@@ -204,13 +206,15 @@ class UserApiControllerTest extends ApiTestSupport {
     void validNicknameTest1() throws Exception {
         //given
         String notExistName = "절대 중복된 이름 아님";
-        ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(notExistName);
 
         //then
-        mockMvc.perform(post("/api/v1/users/valid")
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("nickname", notExistName);
+
+        mockMvc.perform(get("/api/v1/users/valid")
                 .header(AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(validNicknameRequest)))
+                .params(params))
             .andExpect(jsonPath("$.isNotValid").value(true));
     }
 
@@ -222,13 +226,15 @@ class UserApiControllerTest extends ApiTestSupport {
         loginUser.updateUser(existName, List.of(Category.CUSTOMIZABLE), Gender.MALE, 2000,
             AgeGroup.TWENTY, "2호선", "사당역", "testURL");
         userRepository.save(loginUser);
-        ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);
 
         //then
-        mockMvc.perform(post("/api/v1/users/valid")
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("nickname", existName);
+
+        mockMvc.perform(get("/api/v1/users/valid")
                 .header(AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(validNicknameRequest)))
+                .params(params))
             .andExpect(jsonPath("$.isNotValid").value(true));
     }
 
@@ -241,13 +247,14 @@ class UserApiControllerTest extends ApiTestSupport {
 
         String existName = anotherUser.getName();
 
-        ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);
-
         //then
-        mockMvc.perform(post("/api/v1/users/valid")
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("nickname", existName);
+
+        mockMvc.perform(get("/api/v1/users/valid")
                 .header(AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(validNicknameRequest)))
+                .params(params))
             .andExpect(jsonPath("$.isNotValid").value(true));
     }
 
@@ -262,13 +269,13 @@ class UserApiControllerTest extends ApiTestSupport {
             AgeGroup.TWENTY, "2호선", "사당역", "testURL");
         userRepository.save(loginUser);
 
-        ValidNicknameRequest validNicknameRequest = new ValidNicknameRequest(existName);
-
         //then
-        mockMvc.perform(post("/api/v1/users/valid")
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("nickname", existName);
+        mockMvc.perform(get("/api/v1/users/valid")
                 .header(AUTHORIZATION, accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(validNicknameRequest)))
+                .params(params))
             .andExpect(jsonPath("$.isNotValid").value(true));
     }
 }

--- a/core/src/main/java/com/civilwar/boardsignal/auth/application/AuthService.java
+++ b/core/src/main/java/com/civilwar/boardsignal/auth/application/AuthService.java
@@ -7,6 +7,8 @@ import com.civilwar.boardsignal.auth.dto.response.IssueTokenResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLoginResponse;
 import com.civilwar.boardsignal.auth.dto.response.UserLogoutResponse;
 import com.civilwar.boardsignal.auth.mapper.AuthMapper;
+import com.civilwar.boardsignal.user.domain.constants.AgeGroup;
+import com.civilwar.boardsignal.user.domain.constants.Gender;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +36,9 @@ public class AuthService {
                     userLoginRequest.nickname(),
                     userLoginRequest.provider(),
                     userLoginRequest.providerId(),
-                    userLoginRequest.imageUrl()
+                    userLoginRequest.imageUrl(),
+                    Gender.UNKNOWN,
+                    AgeGroup.UNKNOWN
                 )
             );
         }

--- a/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/infrastructure/repository/RoomJpaRepository.java
@@ -37,12 +37,11 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
     // 내가 어제까지 참여한 종료된 모임 (페이징 버전)
     @Query("select r "
         + "from Room as r "
-        + "left join MeetingInfo as m "
+        + "join MeetingInfo as m "
         + "on m.id = r.meetingInfo.id "
         + "join Participant as p "
         + "on r.id = p.roomId "
         + "where p.userId=:userId "
-        + "and r.status='FIX' "
         + "and m.meetingTime<:today "
         + "order by m.meetingTime desc ")
     Slice<Room> findMyEndRoomPaging(@Param("userId") Long userId,
@@ -51,12 +50,11 @@ public interface RoomJpaRepository extends JpaRepository<Room, Long> {
     // 내가 어제까지 참여한 종료된 모임 갯수
     @Query("select count(r) "
         + "from Room as r "
-        + "left join MeetingInfo as m "
+        + "join MeetingInfo as m "
         + "on m.id = r.meetingInfo.id "
         + "join Participant as p "
         + "on r.id = p.roomId "
         + "where p.userId=:userId "
-        + "and r.status='FIX' "
         + "and m.meetingTime<:today "
         + "order by m.meetingTime desc ")
     int countByMyEndRoom(@Param("userId") Long userId, @Param("today") LocalDateTime today);

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/Gender.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/constants/Gender.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Gender {
 
+    UNKNOWN(null, null, "알 수 없음"),
     MALE("male", "M", "남성"),
     FEMALE("female", "F", "여성"),
     UNION(null, null, "혼성");

--- a/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
+++ b/core/src/main/java/com/civilwar/boardsignal/user/domain/entity/User.java
@@ -105,8 +105,8 @@ public class User extends BaseEntity implements UserDetails {
         @NonNull String providerId,
         @NonNull String profileImageUrl,
         int birth,
-        AgeGroup ageGroup,
-        Gender gender
+        @NonNull AgeGroup ageGroup,
+        @NonNull Gender gender
     ) {
         this.email = email;
         this.name = name;
@@ -128,7 +128,9 @@ public class User extends BaseEntity implements UserDetails {
         String nickname,
         String provider,
         String providerId,
-        String profileImageUrl
+        String profileImageUrl,
+        Gender gender,
+        AgeGroup ageGroup
     ) {
         return User.builder()
             .email(email)
@@ -136,6 +138,8 @@ public class User extends BaseEntity implements UserDetails {
             .provider(provider)
             .providerId(providerId)
             .profileImageUrl(profileImageUrl)
+            .gender(gender)
+            .ageGroup(ageGroup)
             .build();
     }
 


### PR DESCRIPTION
### ⛏ 작업 상세 내용

- 이전 작업에서 성별과 연령대를 더 이상 카카오 서버에서 받지 않도록 수정했습니다
- OAuth 첫 로그인 시, 폼에서 가입 처리를 하지 않고 다시 로그인 할 경우 DB에 저장되어 있지 않은 `성별`과 `연령대`를 갖고오는 로직이 있어 에러가 발생했습니다
- '알 수 없음' 성별과 연령대를 추가하여 nullpointerexception을 해결했습니다

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
