### PR TITLE
fix : 채팅방 목록 조회 시, 응답 채팅 데이터 필드 추가

### DIFF
--- a/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
+++ b/api/src/main/java/com/civilwar/boardsignal/user/presentation/UserApiController.java
@@ -20,7 +20,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;

--- a/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/room/presentation/RoomControllerTest.java
@@ -302,7 +302,7 @@ class RoomControllerTest extends ApiTestSupport {
             .andExpect(jsonPath("$.roomsInfos.length()").value(2))
             .andExpect(jsonPath("$.roomsInfos.[0].id").value(room2.getId()))
             .andExpect(jsonPath("$.roomsInfos.[0].unreadChatCount").value(3))
-            .andExpect(jsonPath("$.roomsInfos.[0].lastChatMessage").value("테스트 2"))
+            .andExpect(jsonPath("$.roomsInfos.[0].lastChatMessage.content").value("테스트 2"))
             .andExpect(jsonPath("$.roomsInfos.[1].id").value(room1.getId()))
             .andExpect(jsonPath("$.roomsInfos.[1].unreadChatCount").value(0))
             .andExpect(jsonPath("$.roomsInfos.[1].lastChatMessage").doesNotExist());

--- a/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
+++ b/api/src/test/java/com/civilwar/boardsignal/user/presentation/UserApiControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -28,7 +27,6 @@ import com.civilwar.boardsignal.user.domain.constants.Role;
 import com.civilwar.boardsignal.user.domain.entity.User;
 import com.civilwar.boardsignal.user.domain.repository.UserRepository;
 import com.civilwar.boardsignal.user.dto.request.ApiUserModifyRequest;
-import com.civilwar.boardsignal.user.dto.request.ValidNicknameRequest;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/LastChatMessageDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/LastChatMessageDto.java
@@ -1,8 +1,13 @@
 package com.civilwar.boardsignal.chat.dto.response;
 
+import com.civilwar.boardsignal.chat.domain.constant.MessageType;
+import java.time.LocalDateTime;
+
 public record LastChatMessageDto(
     Long roomId,
-    String content
+    String content,
+    MessageType messageType,
+    LocalDateTime createdAt
 ) {
 
 }

--- a/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/LastChatMessageDto.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/dto/response/LastChatMessageDto.java
@@ -1,12 +1,14 @@
 package com.civilwar.boardsignal.chat.dto.response;
 
 import com.civilwar.boardsignal.chat.domain.constant.MessageType;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record LastChatMessageDto(
     Long roomId,
     String content,
     MessageType messageType,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     LocalDateTime createdAt
 ) {
 

--- a/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
+++ b/core/src/main/java/com/civilwar/boardsignal/chat/infrastructure/repository/ChatMessageJpaRepository.java
@@ -42,7 +42,7 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessage, Lon
 
     //채팅방 별 마지막 메시지 조회
     @Query(
-        "select new com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto(c.roomId, c.content) "
+        "select new com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto(c.roomId, c.content, c.messageType, c.createdAt) "
             + "from ChatMessage as c "
             + "where c.roomId in :roomIds "
             + "and c.createdAt in (select max(c.createdAt) from ChatMessage as c group by c.roomId) ")

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/mapper/RoomMapper.java
@@ -238,11 +238,10 @@ public final class RoomMapper {
             .map(ChatCountDto::uncheckedMessage)
             .orElse(0L);
 
-        String lastChatMessage = lastChatMessages
+        LastChatMessageDto lastChatMessage = lastChatMessages
             .stream()
             .filter(lastChatMessageDto -> lastChatMessageDto.roomId().equals(room.id()))
             .findFirst()
-            .map(LastChatMessageDto::content)
             .orElse(null);
 
         return new ChatRoomResponse(

--- a/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomResponse.java
+++ b/core/src/main/java/com/civilwar/boardsignal/room/dto/response/ChatRoomResponse.java
@@ -1,12 +1,14 @@
 package com.civilwar.boardsignal.room.dto.response;
 
+import com.civilwar.boardsignal.chat.dto.response.LastChatMessageDto;
+
 public record ChatRoomResponse(
     Long id,
     String title,
     String imageUrl,
     int headCount,
     int unreadChatCount,
-    String lastChatMessage
+    LastChatMessageDto lastChatMessage
 ) {
 
 }


### PR DESCRIPTION
### ⛏ 작업 상세 내용
- 모임 별 마지막 채팅에 대한 type & createdAt 필드 추가

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
